### PR TITLE
feat: installer 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,12 @@ jobs:
 
       - name: Build binaries
         run: |
-          GOOS=linux GOARCH=amd64 go build -o nevinho-linux-amd64
-          GOOS=linux GOARCH=arm64 go build -o nevinho-linux-arm64
-          GOOS=darwin GOARCH=amd64 go build -o nevinho-darwin-amd64
-          GOOS=darwin GOARCH=arm64 go build -o nevinho-darwin-arm64
+          VERSION=${GITHUB_REF_NAME}
+          LDFLAGS="-X main.version=${VERSION}"
+          GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -o nevinho-linux-amd64
+          GOOS=linux GOARCH=arm64 go build -ldflags "$LDFLAGS" -o nevinho-linux-arm64
+          GOOS=darwin GOARCH=amd64 go build -ldflags "$LDFLAGS" -o nevinho-darwin-amd64
+          GOOS=darwin GOARCH=arm64 go build -ldflags "$LDFLAGS" -o nevinho-darwin-arm64
 
       - name: Create release
         uses: softprops/action-gh-release@v2

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ lint:
 	@echo "Lint passed."
 
 build:
-	@go build -o bin/nevinho
+	@go build -ldflags "-X main.version=$$(git describe --tags --always)" -o bin/nevinho
 
 run:
 	@go run main.go

--- a/README.md
+++ b/README.md
@@ -8,56 +8,72 @@ A personal agent harness that runs in your Discord DMs.
 Supports Anthropic, OpenAI, and Ollama.
 Comes with tools for web search, code execution, and file management.
 
+## Install
+
+```bash
+curl -sSL https://raw.githubusercontent.com/lucasnevespereira/nevinho/main/install.sh | bash
+```
+
+This downloads the binary and walks you through setup (Discord token, LLM key, etc.).
+
+You can also reconfigure later from Discord with `/config`.
+
+## Manual setup
+
+If you prefer to build from source:
+
+```bash
+git clone https://github.com/lucasnevespereira/nevinho.git
+cd nevinho
+cp .env.example .env
+# fill in DISCORD_BOT_TOKEN, DISCORD_OWNER_ID, and at least one LLM key
+make run
+```
+
+See [setup.md](setup.md) for Discord bot creation steps.
+
 ## Providers
 
-Works with multiple LLM backends. Set one in your `.env`:
+Works with multiple LLM backends:
 
-| Provider  | Env var               | Default model    |
-| --------- | --------------------- | ---------------- |
-| Anthropic | `ANTHROPIC_API_KEY`   | claude-haiku-4-5 |
-| OpenAI    | `OPENAI_API_KEY`      | gpt-4o-mini      |
-| Ollama    | `OLLAMA_MODEL=llama3` | any local model  |
+| Provider | Env var | Default model |
+|----------|---------|---------------|
+| Anthropic | `ANTHROPIC_API_KEY` | claude-haiku-4-5 |
+| OpenAI | `OPENAI_API_KEY` | gpt-4o-mini |
+| Ollama | `OLLAMA_MODEL=llama3` | any local model |
 
 Detection priority: Ollama > Anthropic > OpenAI.
 
-You can switch models at runtime with `/model claude-sonnet-4-6` or `/model gpt-4o`.
-
-## Setup
-
-```bash
-cp .env.example .env
-# fill in DISCORD_BOT_TOKEN, DISCORD_OWNER_ID, and at least one LLM key
-go run main.go
-```
-
-See [SETUP.md](SETUP.md) for Discord bot creation steps.
+Switch models at runtime with `/model claude-sonnet-4-6` or `/model gpt-4o`.
 
 ## Tools
 
-| Tool         | What it does                                |
-| ------------ | ------------------------------------------- |
+| Tool | What it does |
+|------|-------------|
 | `web_search` | Search via Brave API or DuckDuckGo fallback |
-| `web_read`   | Fetch a URL and extract readable text       |
-| `run_code`   | Execute Python, Node, or bash (10s timeout) |
-| `file_read`  | Read a file from workspace or absolute path |
+| `web_read` | Fetch a URL and extract readable text |
+| `run_code` | Execute Python, Node, or bash (10s timeout) |
+| `file_read` | Read a file from workspace or absolute path |
 | `file_write` | Write a file (absolute paths need approval) |
 
 The agent chains tools automatically. Ask it to "find the latest Go release" and it will search, read the page, and summarize.
 
 ## Commands
 
-| Command                 | What it does                          |
-| ----------------------- | ------------------------------------- |
-| `/new`                  | Start a fresh conversation            |
-| `/model`                | Show current model                    |
-| `/model <name>`         | Switch model                          |
-| `/status`               | Uptime, token usage, model info       |
-| `/paths`                | List approved write paths             |
-| `/paths clear`          | Revoke all path permissions           |
-| `/connect <service>`    | Link GitHub or Google via device flow |
-| `/disconnect <service>` | Unlink a service                      |
-| `/accounts`             | Show connected services               |
-| `/help`                 | Show capabilities                     |
+| Command | What it does |
+|---------|-------------|
+| `/new` | Start a fresh conversation |
+| `/model` | Show current model |
+| `/model <name>` | Switch model |
+| `/status` | Uptime, token usage, model info |
+| `/config` | View or update configuration |
+| `/config KEY VALUE` | Set a config value |
+| `/paths` | List approved write paths |
+| `/paths clear` | Revoke all path permissions |
+| `/connect <service>` | Link GitHub or Google via device flow |
+| `/disconnect <service>` | Unlink a service |
+| `/accounts` | Show connected services |
+| `/help` | Show capabilities |
 
 All commands also work as plain text messages in the DM.
 
@@ -73,20 +89,25 @@ Dangerous operations require approval before execution.
 
 ## Config
 
-Data lives in `~/.config/nevinho/`:
+Configuration is encrypted and stored in `~/.config/nevinho/`:
 
 ```
+config.enc          encrypted configuration (AES-256-GCM)
+credentials.enc     encrypted OAuth tokens
+secret.key          auto-generated encryption key
 workspace/          per-user sandboxed file storage
 approved_paths.json persisted write permissions
-credentials.enc     encrypted OAuth tokens (AES-256-GCM)
-secret.key          auto-generated encryption key
 ```
+
+You can also use a `.env` file in the project directory for development. Env vars take priority over encrypted config.
 
 ## Project structure
 
 ```
-main.go      entry point, provider detection
+main.go      entry point, provider detection, setup
 agent/       chat loop, tool orchestration, approval flow
+config/      encrypted configuration management
+crypto/      shared AES-256-GCM encryption
 llm/         provider interface (Anthropic, OpenAI, Ollama)
 tools/       web search, code execution, file I/O
 discord/     bot, slash commands, message handling

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -40,16 +40,10 @@ const (
 - If a write fails due to permissions, tell the user which directory needs access.`
 )
 
-type ProviderConfig struct {
-	AnthropicKey string
-	OpenAIKey    string
-	OllamaURL    string
-}
-
 type Agent struct {
-	llm    llm.Provider
-	tools  *tools.Registry
-	config ProviderConfig
+	llm   llm.Provider
+	tools *tools.Registry
+	cfg   *config.Config
 
 	mu          sync.Mutex
 	history     map[string][]json.RawMessage
@@ -58,11 +52,11 @@ type Agent struct {
 	totalTokens int
 }
 
-func New(provider llm.Provider, providerCfg ProviderConfig, cfg *config.Config) *Agent {
+func New(provider llm.Provider, cfg *config.Config) *Agent {
 	return &Agent{
 		llm:       provider,
 		tools:     tools.NewRegistry(cfg),
-		config:    providerCfg,
+		cfg:       cfg,
 		history:   make(map[string][]json.RawMessage),
 		userLock:  make(map[string]*sync.Mutex),
 		startTime: time.Now(),
@@ -163,23 +157,24 @@ func (a *Agent) Model() string {
 }
 
 func (a *Agent) SwitchModel(name string) error {
+	pc := a.cfg.ProviderConfig()
 	var p llm.Provider
 	switch {
 	case strings.HasPrefix(name, "gpt-") || strings.HasPrefix(name, "o1-") || strings.HasPrefix(name, "o3-") || strings.HasPrefix(name, "o4-"):
-		if a.config.OpenAIKey == "" {
+		if pc.OpenAIKey == "" {
 			return fmt.Errorf("OPENAI_API_KEY not configured")
 		}
-		p = llm.NewOpenAI(a.config.OpenAIKey, "", name)
+		p = llm.NewOpenAI(pc.OpenAIKey, "", name)
 	case strings.HasPrefix(name, "claude-"):
-		if a.config.AnthropicKey == "" {
+		if pc.AnthropicKey == "" {
 			return fmt.Errorf("ANTHROPIC_API_KEY not configured")
 		}
-		p = llm.NewAnthropic(a.config.AnthropicKey, "", name)
+		p = llm.NewAnthropic(pc.AnthropicKey, "", name)
 	default:
-		if a.config.OllamaURL != "" {
-			p = llm.NewOpenAI("", a.config.OllamaURL, name)
-		} else if a.config.OpenAIKey != "" {
-			p = llm.NewOpenAI(a.config.OpenAIKey, "", name)
+		if pc.OllamaURL != "" {
+			p = llm.NewOpenAI("", pc.OllamaURL, name)
+		} else if pc.OpenAIKey != "" {
+			p = llm.NewOpenAI(pc.OpenAIKey, "", name)
 		} else {
 			return fmt.Errorf("unknown model: %s", name)
 		}
@@ -223,12 +218,6 @@ func (a *Agent) ApprovedPaths() []string {
 
 func (a *Agent) ClearApprovedPaths() {
 	a.tools.ClearApprovedPaths()
-}
-
-func (a *Agent) UpdateConfig(pc ProviderConfig) {
-	a.mu.Lock()
-	a.config = pc
-	a.mu.Unlock()
 }
 
 func (a *Agent) addTokens(n int) {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -41,9 +41,10 @@ const (
 )
 
 type Agent struct {
-	llm   llm.Provider
-	tools *tools.Registry
-	cfg   *config.Config
+	llm     llm.Provider
+	tools   *tools.Registry
+	cfg     *config.Config
+	version string
 
 	mu          sync.Mutex
 	history     map[string][]json.RawMessage
@@ -52,11 +53,12 @@ type Agent struct {
 	totalTokens int
 }
 
-func New(provider llm.Provider, cfg *config.Config) *Agent {
+func New(provider llm.Provider, cfg *config.Config, version string) *Agent {
 	return &Agent{
 		llm:       provider,
 		tools:     tools.NewRegistry(cfg),
 		cfg:       cfg,
+		version:   version,
 		history:   make(map[string][]json.RawMessage),
 		userLock:  make(map[string]*sync.Mutex),
 		startTime: time.Now(),
@@ -198,12 +200,12 @@ func (a *Agent) Status() string {
 	paths := a.tools.ApprovedPaths()
 
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "**nevinho status**\n"+
+	fmt.Fprintf(&sb, "**nevinho %s**\n"+
 		"• Model: `%s`\n"+
 		"• Uptime: %s\n"+
 		"• Session tokens: %d\n"+
 		"• Approved paths: %d",
-		a.llm.Model(), formatDuration(uptime), tokens, len(paths))
+		a.version, a.llm.Model(), formatDuration(uptime), tokens, len(paths))
 
 	for _, p := range paths {
 		fmt.Fprintf(&sb, "\n  `%s`", p)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/lucasnevespereira/nevinho/config"
 	"github.com/lucasnevespereira/nevinho/llm"
 	"github.com/lucasnevespereira/nevinho/logger"
 	"github.com/lucasnevespereira/nevinho/tools"
@@ -57,11 +58,11 @@ type Agent struct {
 	totalTokens int
 }
 
-func New(provider llm.Provider, config ProviderConfig) *Agent {
+func New(provider llm.Provider, providerCfg ProviderConfig, cfg *config.Config) *Agent {
 	return &Agent{
 		llm:       provider,
-		tools:     tools.NewRegistry(),
-		config:    config,
+		tools:     tools.NewRegistry(cfg),
+		config:    providerCfg,
 		history:   make(map[string][]json.RawMessage),
 		userLock:  make(map[string]*sync.Mutex),
 		startTime: time.Now(),
@@ -222,6 +223,12 @@ func (a *Agent) ApprovedPaths() []string {
 
 func (a *Agent) ClearApprovedPaths() {
 	a.tools.ClearApprovedPaths()
+}
+
+func (a *Agent) UpdateConfig(pc ProviderConfig) {
+	a.mu.Lock()
+	a.config = pc
+	a.mu.Unlock()
 }
 
 func (a *Agent) addTokens(n int) {

--- a/auth/store.go
+++ b/auth/store.go
@@ -1,15 +1,13 @@
 package auth
 
 import (
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/rand"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/lucasnevespereira/nevinho/crypto"
 )
 
 // Service identifies an external service.
@@ -49,7 +47,7 @@ type Store struct {
 
 // NewStore creates a credential store, loading existing tokens from disk.
 func NewStore(configDir string) (*Store, error) {
-	key, err := loadOrCreateKey(configDir)
+	key, err := crypto.LoadOrCreateKey(configDir)
 	if err != nil {
 		return nil, fmt.Errorf("auth key: %w", err)
 	}
@@ -113,7 +111,7 @@ func (s *Store) load() error {
 	if err != nil {
 		return err
 	}
-	plain, err := decrypt(s.key, enc)
+	plain, err := crypto.Decrypt(s.key, enc)
 	if err != nil {
 		return err
 	}
@@ -125,70 +123,9 @@ func (s *Store) save() error {
 	if err != nil {
 		return err
 	}
-	enc, err := encrypt(s.key, plain)
+	enc, err := crypto.Encrypt(s.key, plain)
 	if err != nil {
 		return err
 	}
 	return os.WriteFile(s.filePath, enc, 0600)
-}
-
-func encrypt(key [32]byte, plaintext []byte) ([]byte, error) {
-	block, err := aes.NewCipher(key[:])
-	if err != nil {
-		return nil, err
-	}
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, err
-	}
-	nonce := make([]byte, gcm.NonceSize())
-	if _, err := rand.Read(nonce); err != nil {
-		return nil, err
-	}
-	return gcm.Seal(nonce, nonce, plaintext, nil), nil
-}
-
-func decrypt(key [32]byte, ciphertext []byte) ([]byte, error) {
-	block, err := aes.NewCipher(key[:])
-	if err != nil {
-		return nil, err
-	}
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, err
-	}
-	if len(ciphertext) < gcm.NonceSize() {
-		return nil, fmt.Errorf("ciphertext too short")
-	}
-	nonce := ciphertext[:gcm.NonceSize()]
-	return gcm.Open(nil, nonce, ciphertext[gcm.NonceSize():], nil)
-}
-
-func loadOrCreateKey(configDir string) ([32]byte, error) {
-	// Prefer env var
-	if secret := os.Getenv("NEVINHO_SECRET"); secret != "" {
-		return sha256.Sum256([]byte(secret)), nil
-	}
-
-	// Fall back to auto-generated key file
-	keyFile := filepath.Join(configDir, "secret.key")
-	data, err := os.ReadFile(keyFile)
-	if err == nil && len(data) == 32 {
-		var key [32]byte
-		copy(key[:], data)
-		return key, nil
-	}
-
-	// Generate new key
-	var key [32]byte
-	if _, err := rand.Read(key[:]); err != nil {
-		return key, fmt.Errorf("generate key: %w", err)
-	}
-	if err := os.MkdirAll(configDir, 0755); err != nil {
-		return key, err
-	}
-	if err := os.WriteFile(keyFile, key[:], 0600); err != nil {
-		return key, err
-	}
-	return key, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -148,12 +148,21 @@ func (c *Config) Keys() []KeyStatus {
 	return out
 }
 
-// ValidKeys returns the list of accepted key names.
-func ValidKeys() []string {
-	return []string{
-		"DISCORD_BOT_TOKEN", "DISCORD_OWNER_ID",
-		"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OLLAMA_MODEL",
-		"BRAVE_API_KEY",
-		"GITHUB_CLIENT_ID", "GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET",
+type ProviderConfig struct {
+	AnthropicKey string
+	OpenAIKey    string
+	OllamaURL    string
+}
+
+func (c *Config) ProviderConfig() ProviderConfig {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	pc := ProviderConfig{
+		AnthropicKey: c.AnthropicAPIKey,
+		OpenAIKey:    c.OpenAIAPIKey,
 	}
+	if c.OllamaModel != "" {
+		pc.OllamaURL = "http://localhost:11434"
+	}
+	return pc
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,159 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/lucasnevespereira/nevinho/crypto"
+)
+
+type Config struct {
+	mu       sync.RWMutex
+	dir      string
+	key      [32]byte
+	filePath string
+
+	DiscordBotToken    string `json:"discord_bot_token"`
+	DiscordOwnerID     string `json:"discord_owner_id"`
+	AnthropicAPIKey    string `json:"anthropic_api_key"`
+	OpenAIAPIKey       string `json:"openai_api_key"`
+	OllamaModel        string `json:"ollama_model"`
+	BraveAPIKey        string `json:"brave_api_key"`
+	GitHubClientID     string `json:"github_client_id"`
+	GoogleClientID     string `json:"google_client_id"`
+	GoogleClientSecret string `json:"google_client_secret"`
+}
+
+// keymap maps user-facing key names to struct field pointers.
+func (c *Config) keymap() map[string]*string {
+	return map[string]*string{
+		"DISCORD_BOT_TOKEN":    &c.DiscordBotToken,
+		"DISCORD_OWNER_ID":     &c.DiscordOwnerID,
+		"ANTHROPIC_API_KEY":    &c.AnthropicAPIKey,
+		"OPENAI_API_KEY":       &c.OpenAIAPIKey,
+		"OLLAMA_MODEL":         &c.OllamaModel,
+		"BRAVE_API_KEY":        &c.BraveAPIKey,
+		"GITHUB_CLIENT_ID":     &c.GitHubClientID,
+		"GOOGLE_CLIENT_ID":     &c.GoogleClientID,
+		"GOOGLE_CLIENT_SECRET": &c.GoogleClientSecret,
+	}
+}
+
+type KeyStatus struct {
+	Name   string
+	Set    bool
+	Source string // "config" or "env"
+}
+
+func Load(configDir string) (*Config, error) {
+	key, err := crypto.LoadOrCreateKey(configDir)
+	if err != nil {
+		return nil, fmt.Errorf("config key: %w", err)
+	}
+
+	c := &Config{
+		dir:      configDir,
+		key:      key,
+		filePath: filepath.Join(configDir, "config.enc"),
+	}
+
+	// Load encrypted config if it exists
+	if data, err := os.ReadFile(c.filePath); err == nil {
+		if plain, err := crypto.Decrypt(c.key, data); err == nil {
+			json.Unmarshal(plain, c)
+		}
+	}
+
+	// Env vars override encrypted config (per-key)
+	for envKey, field := range c.keymap() {
+		if val := os.Getenv(envKey); val != "" {
+			*field = val
+		}
+	}
+
+	return c, nil
+}
+
+func (c *Config) Save() error {
+	c.mu.RLock()
+	plain, err := json.Marshal(c)
+	c.mu.RUnlock()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(c.dir, 0755); err != nil {
+		return err
+	}
+
+	enc, err := crypto.Encrypt(c.key, plain)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(c.filePath, enc, 0600)
+}
+
+func (c *Config) Get(key string) (string, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	field, ok := c.keymap()[key]
+	if !ok {
+		return "", fmt.Errorf("unknown key: %s", key)
+	}
+	return *field, nil
+}
+
+func (c *Config) Set(key, value string) error {
+	c.mu.Lock()
+	field, ok := c.keymap()[key]
+	if !ok {
+		c.mu.Unlock()
+		return fmt.Errorf("unknown key: %s", key)
+	}
+	*field = value
+	c.mu.Unlock()
+	return c.Save()
+}
+
+func (c *Config) Delete(key string) error {
+	return c.Set(key, "")
+}
+
+func (c *Config) Keys() []KeyStatus {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	order := []string{
+		"DISCORD_BOT_TOKEN", "DISCORD_OWNER_ID",
+		"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OLLAMA_MODEL",
+		"BRAVE_API_KEY",
+		"GITHUB_CLIENT_ID", "GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET",
+	}
+
+	km := c.keymap()
+	var out []KeyStatus
+	for _, name := range order {
+		field := km[name]
+		status := KeyStatus{Name: name, Set: *field != ""}
+		if status.Set && os.Getenv(name) != "" {
+			status.Source = "env"
+		} else if status.Set {
+			status.Source = "config"
+		}
+		out = append(out, status)
+	}
+	return out
+}
+
+// ValidKeys returns the list of accepted key names.
+func ValidKeys() []string {
+	return []string{
+		"DISCORD_BOT_TOKEN", "DISCORD_OWNER_ID",
+		"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OLLAMA_MODEL",
+		"BRAVE_API_KEY",
+		"GITHUB_CLIENT_ID", "GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET",
+	}
+}

--- a/config/setup.go
+++ b/config/setup.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func RunSetup(configDir string) error {
+	fmt.Println("nevinho setup")
+	fmt.Println()
+
+	scanner := bufio.NewScanner(os.Stdin)
+	prompt := func(label string) string {
+		fmt.Printf("%s: ", label)
+		scanner.Scan()
+		return strings.TrimSpace(scanner.Text())
+	}
+
+	cfg, err := Load(configDir)
+	if err != nil {
+		return fmt.Errorf("failed to init config: %w", err)
+	}
+
+	cfg.DiscordBotToken = prompt("Discord bot token")
+	cfg.DiscordOwnerID = prompt("Discord owner ID")
+
+	fmt.Println()
+	fmt.Println("LLM provider:")
+	fmt.Println("  1) Anthropic (Claude)")
+	fmt.Println("  2) OpenAI (GPT)")
+	fmt.Println("  3) Ollama (local)")
+	choice := prompt("Choice [1/2/3]")
+
+	switch choice {
+	case "1":
+		cfg.AnthropicAPIKey = prompt("Anthropic API key")
+	case "2":
+		cfg.OpenAIAPIKey = prompt("OpenAI API key")
+	case "3":
+		cfg.OllamaModel = prompt("Ollama model name (e.g. llama3)")
+	}
+
+	brave := prompt("Brave Search API key (optional, press Enter to skip)")
+	if brave != "" {
+		cfg.BraveAPIKey = brave
+	}
+
+	if err := cfg.Save(); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	fmt.Println()
+	fmt.Printf("Config saved to %s\n", configDir)
+	fmt.Println("Run 'nevinho' to start.")
+	return nil
+}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -1,0 +1,69 @@
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func Encrypt(key [32]byte, plaintext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+	return gcm.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+func Decrypt(key [32]byte, ciphertext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	if len(ciphertext) < gcm.NonceSize() {
+		return nil, fmt.Errorf("ciphertext too short")
+	}
+	nonce := ciphertext[:gcm.NonceSize()]
+	return gcm.Open(nil, nonce, ciphertext[gcm.NonceSize():], nil)
+}
+
+func LoadOrCreateKey(configDir string) ([32]byte, error) {
+	if secret := os.Getenv("NEVINHO_SECRET"); secret != "" {
+		return sha256.Sum256([]byte(secret)), nil
+	}
+
+	keyFile := filepath.Join(configDir, "secret.key")
+	data, err := os.ReadFile(keyFile)
+	if err == nil && len(data) == 32 {
+		var key [32]byte
+		copy(key[:], data)
+		return key, nil
+	}
+
+	var key [32]byte
+	if _, err := rand.Read(key[:]); err != nil {
+		return key, fmt.Errorf("generate key: %w", err)
+	}
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return key, err
+	}
+	if err := os.WriteFile(keyFile, key[:], 0600); err != nil {
+		return key, err
+	}
+	return key, nil
+}

--- a/discord/bot.go
+++ b/discord/bot.go
@@ -665,14 +665,6 @@ func (b *Bot) configDelete(key string) string {
 }
 
 func (b *Bot) reloadProvider() {
-	pc := agent.ProviderConfig{
-		AnthropicKey: b.cfg.AnthropicAPIKey,
-		OpenAIKey:    b.cfg.OpenAIAPIKey,
-	}
-	if b.cfg.OllamaModel != "" {
-		pc.OllamaURL = "http://localhost:11434"
-	}
-	b.agent.UpdateConfig(pc)
 	b.agent.SwitchModel(b.agent.Model())
 }
 

--- a/discord/bot.go
+++ b/discord/bot.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"strings"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/lucasnevespereira/nevinho/agent"
 	"github.com/lucasnevespereira/nevinho/auth"
+	"github.com/lucasnevespereira/nevinho/config"
 )
 
 const maxMessageLen = 2000
@@ -19,10 +19,11 @@ type Bot struct {
 	ownerID     string
 	agent       *agent.Agent
 	credentials *auth.Store
+	cfg         *config.Config
 	cmds        []*discordgo.ApplicationCommand
 }
 
-func New(token, ownerID string, a *agent.Agent, creds *auth.Store) (*Bot, error) {
+func New(token, ownerID string, a *agent.Agent, creds *auth.Store, cfg *config.Config) (*Bot, error) {
 	session, err := discordgo.New("Bot " + token)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Discord session: %w", err)
@@ -35,6 +36,7 @@ func New(token, ownerID string, a *agent.Agent, creds *auth.Store) (*Bot, error)
 		ownerID:     ownerID,
 		agent:       a,
 		credentials: creds,
+		cfg:         cfg,
 	}
 
 	session.AddHandler(bot.onMessage)
@@ -131,6 +133,24 @@ var slashCommands = []*discordgo.ApplicationCommand{
 	{
 		Name:        "help",
 		Description: "Show available commands and capabilities",
+	},
+	{
+		Name:        "config",
+		Description: "View or update configuration",
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Type:        discordgo.ApplicationCommandOptionString,
+				Name:        "key",
+				Description: "Config key to set (e.g. ANTHROPIC_API_KEY)",
+				Required:    false,
+			},
+			{
+				Type:        discordgo.ApplicationCommandOptionString,
+				Name:        "value",
+				Description: "New value (message is ephemeral, only you see it)",
+				Required:    false,
+			},
+		},
 	},
 }
 
@@ -231,6 +251,10 @@ func (b *Bot) onInteraction(s *discordgo.Session, i *discordgo.InteractionCreate
 
 	case "accounts":
 		reply = b.handleAccounts(userID)
+
+	case "config":
+		b.handleConfigSlash(s, i, data)
+		return
 	}
 
 	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
@@ -254,7 +278,7 @@ func (b *Bot) handleConnect(s *discordgo.Session, i *discordgo.InteractionCreate
 
 	switch svc {
 	case auth.GitHub:
-		clientID := os.Getenv("GITHUB_CLIENT_ID")
+		clientID := b.cfg.GitHubClientID
 		if clientID == "" {
 			respond(s, i, "GitHub not configured. Set `GITHUB_CLIENT_ID` in .env\n\nCreate one at: https://github.com/settings/applications/new")
 			return
@@ -275,8 +299,8 @@ func (b *Bot) handleConnect(s *discordgo.Session, i *discordgo.InteractionCreate
 		go b.pollGitHub(s, i.ChannelID, userID, flow, dc)
 
 	case auth.Google:
-		clientID := os.Getenv("GOOGLE_CLIENT_ID")
-		clientSecret := os.Getenv("GOOGLE_CLIENT_SECRET")
+		clientID := b.cfg.GoogleClientID
+		clientSecret := b.cfg.GoogleClientSecret
 		if clientID == "" || clientSecret == "" {
 			respond(s, i, "Google not configured. Set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` in .env\n\nCreate at: https://console.cloud.google.com/apis/credentials")
 			return
@@ -440,6 +464,19 @@ func (b *Bot) onMessage(s *discordgo.Session, m *discordgo.MessageCreate) {
 		service := strings.TrimSpace(text[12:])
 		s.ChannelMessageSend(m.ChannelID, b.handleDisconnect(m.Author.ID, service))
 		return
+	case lower == "/config":
+		s.ChannelMessageSend(m.ChannelID, b.configStatus())
+		return
+	case strings.HasPrefix(lower, "/config "):
+		// Delete the message immediately since it may contain a secret
+		s.ChannelMessageDelete(m.ChannelID, m.ID)
+		parts := strings.Fields(text[8:])
+		if len(parts) == 1 {
+			s.ChannelMessageSend(m.ChannelID, b.configDelete(parts[0]))
+		} else if len(parts) >= 2 {
+			s.ChannelMessageSend(m.ChannelID, b.configSet(parts[0], strings.Join(parts[1:], " ")))
+		}
+		return
 	}
 
 	s.ChannelTyping(m.ChannelID)
@@ -476,7 +513,7 @@ func (b *Bot) handleConnectText(s *discordgo.Session, channelID, userID, service
 
 	switch svc {
 	case auth.GitHub:
-		clientID := os.Getenv("GITHUB_CLIENT_ID")
+		clientID := b.cfg.GitHubClientID
 		if clientID == "" {
 			s.ChannelMessageSend(channelID, "GitHub not configured. Set `GITHUB_CLIENT_ID` in .env")
 			return
@@ -494,8 +531,8 @@ func (b *Bot) handleConnectText(s *discordgo.Session, channelID, userID, service
 		go b.pollGitHub(s, channelID, userID, flow, dc)
 
 	case auth.Google:
-		clientID := os.Getenv("GOOGLE_CLIENT_ID")
-		clientSecret := os.Getenv("GOOGLE_CLIENT_SECRET")
+		clientID := b.cfg.GoogleClientID
+		clientSecret := b.cfg.GoogleClientSecret
 		if clientID == "" || clientSecret == "" {
 			s.ChannelMessageSend(channelID, "Google not configured. Set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` in .env")
 			return
@@ -541,24 +578,127 @@ func splitMessage(text string) []string {
 	return chunks
 }
 
+func (b *Bot) handleConfigSlash(s *discordgo.Session, i *discordgo.InteractionCreate, data discordgo.ApplicationCommandInteractionData) {
+	var key, value string
+	for _, opt := range data.Options {
+		switch opt.Name {
+		case "key":
+			key = opt.StringValue()
+		case "value":
+			value = opt.StringValue()
+		}
+	}
+
+	// No args: show current config
+	if key == "" {
+		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: b.configStatus(),
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	// Key + value: update
+	if value != "" {
+		reply := b.configSet(key, value)
+		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: reply,
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	// Key only: delete
+	reply := b.configDelete(key)
+	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: reply,
+			Flags:   discordgo.MessageFlagsEphemeral,
+		},
+	})
+}
+
+func (b *Bot) configStatus() string {
+	keys := b.cfg.Keys()
+	var sb strings.Builder
+	sb.WriteString("**Configuration**\n")
+	for _, k := range keys {
+		if k.Set {
+			fmt.Fprintf(&sb, "• `%s`: set (%s)\n", k.Name, k.Source)
+		} else {
+			fmt.Fprintf(&sb, "• `%s`: not set\n", k.Name)
+		}
+	}
+	sb.WriteString("\nUpdate: `/config key:KEY value:VALUE`")
+	sb.WriteString("\nClear: `/config key:KEY`")
+	return sb.String()
+}
+
+func (b *Bot) configSet(key, value string) string {
+	if err := b.cfg.Set(key, value); err != nil {
+		return fmt.Sprintf("Failed: %v", err)
+	}
+
+	// Reload provider if an LLM key changed
+	if isLLMKey(key) {
+		b.reloadProvider()
+	}
+
+	return fmt.Sprintf("Updated `%s`.", key)
+}
+
+func (b *Bot) configDelete(key string) string {
+	if err := b.cfg.Delete(key); err != nil {
+		return fmt.Sprintf("Failed: %v", err)
+	}
+	if isLLMKey(key) {
+		b.reloadProvider()
+	}
+	return fmt.Sprintf("Cleared `%s`.", key)
+}
+
+func (b *Bot) reloadProvider() {
+	pc := agent.ProviderConfig{
+		AnthropicKey: b.cfg.AnthropicAPIKey,
+		OpenAIKey:    b.cfg.OpenAIAPIKey,
+	}
+	if b.cfg.OllamaModel != "" {
+		pc.OllamaURL = "http://localhost:11434"
+	}
+	b.agent.UpdateConfig(pc)
+	b.agent.SwitchModel(b.agent.Model())
+}
+
+func isLLMKey(key string) bool {
+	return key == "ANTHROPIC_API_KEY" || key == "OPENAI_API_KEY" || key == "OLLAMA_MODEL"
+}
+
 func helpMessage() string {
-	return `**nevinho** — your AI assistant
+	return `**nevinho**
 
 **What I can do:**
 • Browse the web and read articles
 • Search the web for information
 • Run code (Python, JavaScript, bash)
-• Save and read files (notes, code, etc.)
+• Save and read files
 
 **Commands:**
-• /new — start a fresh conversation
-• /model — show or switch model
-• /status — uptime, tokens, model info
-• /paths — manage approved write paths
-• /connect — link GitHub or Google account
-• /disconnect — unlink a service
-• /accounts — show connected services
-• /help — show this message
+• /new start a fresh conversation
+• /model show or switch model
+• /status uptime, tokens, model info
+• /paths manage approved write paths
+• /config view or update configuration
+• /connect link GitHub or Google account
+• /disconnect unlink a service
+• /accounts show connected services
+• /help show this message
 
-Just type what you need. I'll figure it out.`
+Just type what you need.`
 }

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+
+REPO="lucasnevespereira/nevinho"
+INSTALL_DIR="$HOME/.local/bin"
+
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$ARCH" in
+  x86_64) ARCH="amd64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+case "$OS" in
+  linux|darwin) ;;
+  *) echo "Unsupported OS: $OS"; exit 1 ;;
+esac
+
+BINARY="nevinho-${OS}-${ARCH}"
+
+echo "Fetching latest release..."
+LATEST=$(curl -sSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | cut -d'"' -f4)
+if [ -z "$LATEST" ]; then
+  echo "No releases found."
+  exit 1
+fi
+
+echo "Downloading nevinho ${LATEST} (${OS}/${ARCH})..."
+curl -sSL "https://github.com/${REPO}/releases/download/${LATEST}/${BINARY}" -o /tmp/nevinho
+chmod +x /tmp/nevinho
+
+mkdir -p "$INSTALL_DIR"
+mv /tmp/nevinho "$INSTALL_DIR/nevinho"
+echo "Installed to ${INSTALL_DIR}/nevinho"
+
+# Add to PATH if not already there
+if ! echo "$PATH" | grep -q "$INSTALL_DIR"; then
+  echo ""
+  echo "Add this to your shell profile (.bashrc, .zshrc, etc.):"
+  echo "  export PATH=\"\$HOME/.local/bin:\$PATH\""
+  echo ""
+  export PATH="$INSTALL_DIR:$PATH"
+fi
+
+echo ""
+echo "Running setup..."
+echo ""
+nevinho --setup

--- a/main.go
+++ b/main.go
@@ -1,15 +1,19 @@
 package main
 
 import (
+	"bufio"
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/joho/godotenv"
 	"github.com/lucasnevespereira/nevinho/agent"
 	"github.com/lucasnevespereira/nevinho/auth"
+	"github.com/lucasnevespereira/nevinho/config"
 	"github.com/lucasnevespereira/nevinho/discord"
 	"github.com/lucasnevespereira/nevinho/llm"
 	"github.com/lucasnevespereira/nevinho/logger"
@@ -17,36 +21,39 @@ import (
 
 func main() {
 	_ = godotenv.Load()
-	logger.Init()
-
-	token := os.Getenv("DISCORD_BOT_TOKEN")
-	if token == "" {
-		log.Fatal("DISCORD_BOT_TOKEN is required")
-	}
-
-	ownerID := os.Getenv("DISCORD_OWNER_ID")
-	if ownerID == "" {
-		log.Fatal("DISCORD_OWNER_ID is required (your Discord user ID)")
-	}
-
-	config := agent.ProviderConfig{
-		AnthropicKey: os.Getenv("ANTHROPIC_API_KEY"),
-		OpenAIKey:    os.Getenv("OPENAI_API_KEY"),
-	}
-	if os.Getenv("OLLAMA_MODEL") != "" {
-		config.OllamaURL = "http://localhost:11434"
-	}
 
 	home, _ := os.UserHomeDir()
 	configDir := filepath.Join(home, ".config", "nevinho")
+
+	if len(os.Args) > 1 && os.Args[1] == "--setup" {
+		runSetup(configDir)
+		return
+	}
+
+	logger.Init()
+
+	cfg, err := config.Load(configDir)
+	if err != nil {
+		log.Fatalf("failed to load config: %v", err)
+	}
+
+	if cfg.DiscordBotToken == "" {
+		log.Fatal("DISCORD_BOT_TOKEN is required (run nevinho --setup or set in .env)")
+	}
+	if cfg.DiscordOwnerID == "" {
+		log.Fatal("DISCORD_OWNER_ID is required (run nevinho --setup or set in .env)")
+	}
+
+	providerCfg := buildProviderConfig(cfg)
+	provider := detectProvider(cfg, providerCfg)
+
 	creds, err := auth.NewStore(configDir)
 	if err != nil {
 		log.Fatalf("failed to init credentials: %v", err)
 	}
 
-	provider := detectProvider(config)
-	a := agent.New(provider, config)
-	bot, err := discord.New(token, ownerID, a, creds)
+	a := agent.New(provider, providerCfg, cfg)
+	bot, err := discord.New(cfg.DiscordBotToken, cfg.DiscordOwnerID, a, creds, cfg)
 	if err != nil {
 		log.Fatalf("failed to create bot: %v", err)
 	}
@@ -65,21 +72,79 @@ func main() {
 	bot.Stop()
 }
 
-func detectProvider(config agent.ProviderConfig) llm.Provider {
-	ollamaModel := os.Getenv("OLLAMA_MODEL")
+func buildProviderConfig(cfg *config.Config) agent.ProviderConfig {
+	pc := agent.ProviderConfig{
+		AnthropicKey: cfg.AnthropicAPIKey,
+		OpenAIKey:    cfg.OpenAIAPIKey,
+	}
+	if cfg.OllamaModel != "" {
+		pc.OllamaURL = "http://localhost:11434"
+	}
+	return pc
+}
 
+func detectProvider(cfg *config.Config, pc agent.ProviderConfig) llm.Provider {
 	switch {
-	case ollamaModel != "":
-		logger.Info("provider: ollama (" + ollamaModel + ")")
-		return llm.NewOpenAI("", config.OllamaURL, ollamaModel)
-	case config.AnthropicKey != "":
+	case cfg.OllamaModel != "":
+		logger.Info("provider: ollama (" + cfg.OllamaModel + ")")
+		return llm.NewOpenAI("", pc.OllamaURL, cfg.OllamaModel)
+	case pc.AnthropicKey != "":
 		logger.Info("provider: anthropic")
-		return llm.NewAnthropic(config.AnthropicKey, "", "")
-	case config.OpenAIKey != "":
+		return llm.NewAnthropic(pc.AnthropicKey, "", "")
+	case pc.OpenAIKey != "":
 		logger.Info("provider: openai")
-		return llm.NewOpenAI(config.OpenAIKey, "", "")
+		return llm.NewOpenAI(pc.OpenAIKey, "", "")
 	default:
-		log.Fatal("set ANTHROPIC_API_KEY, OPENAI_API_KEY, or OLLAMA_MODEL in .env")
+		log.Fatal("no LLM provider configured (run nevinho --setup or set keys in .env)")
 		return nil
 	}
+}
+
+func runSetup(configDir string) {
+	fmt.Println("nevinho setup")
+	fmt.Println()
+
+	scanner := bufio.NewScanner(os.Stdin)
+	prompt := func(label string) string {
+		fmt.Printf("%s: ", label)
+		scanner.Scan()
+		return strings.TrimSpace(scanner.Text())
+	}
+
+	cfg, err := config.Load(configDir)
+	if err != nil {
+		log.Fatalf("failed to init config: %v", err)
+	}
+
+	cfg.DiscordBotToken = prompt("Discord bot token")
+	cfg.DiscordOwnerID = prompt("Discord owner ID")
+
+	fmt.Println()
+	fmt.Println("LLM provider:")
+	fmt.Println("  1) Anthropic (Claude)")
+	fmt.Println("  2) OpenAI (GPT)")
+	fmt.Println("  3) Ollama (local)")
+	choice := prompt("Choice [1/2/3]")
+
+	switch choice {
+	case "1":
+		cfg.AnthropicAPIKey = prompt("Anthropic API key")
+	case "2":
+		cfg.OpenAIAPIKey = prompt("OpenAI API key")
+	case "3":
+		cfg.OllamaModel = prompt("Ollama model name (e.g. llama3)")
+	}
+
+	brave := prompt("Brave Search API key (optional, press Enter to skip)")
+	if brave != "" {
+		cfg.BraveAPIKey = brave
+	}
+
+	if err := cfg.Save(); err != nil {
+		log.Fatalf("failed to save config: %v", err)
+	}
+
+	fmt.Println()
+	fmt.Printf("Config saved to %s\n", configDir)
+	fmt.Println("Run 'nevinho' to start.")
 }

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -16,11 +17,18 @@ import (
 	"github.com/lucasnevespereira/nevinho/logger"
 )
 
+var version = "dev"
+
 func main() {
 	_ = godotenv.Load()
 
 	home, _ := os.UserHomeDir()
 	configDir := filepath.Join(home, ".config", "nevinho")
+
+	if len(os.Args) > 1 && os.Args[1] == "--version" {
+		fmt.Println("nevinho " + version)
+		return
+	}
 
 	if len(os.Args) > 1 && os.Args[1] == "--setup" {
 		if err := config.RunSetup(configDir); err != nil {
@@ -50,7 +58,7 @@ func main() {
 		log.Fatalf("failed to init credentials: %v", err)
 	}
 
-	a := agent.New(provider, cfg)
+	a := agent.New(provider, cfg, version)
 	bot, err := discord.New(cfg.DiscordBotToken, cfg.DiscordOwnerID, a, creds, cfg)
 	if err != nil {
 		log.Fatalf("failed to create bot: %v", err)

--- a/main.go
+++ b/main.go
@@ -1,13 +1,10 @@
 package main
 
 import (
-	"bufio"
-	"fmt"
 	"log"
 	"os"
 	"os/signal"
 	"path/filepath"
-	"strings"
 	"syscall"
 
 	"github.com/joho/godotenv"
@@ -26,7 +23,9 @@ func main() {
 	configDir := filepath.Join(home, ".config", "nevinho")
 
 	if len(os.Args) > 1 && os.Args[1] == "--setup" {
-		runSetup(configDir)
+		if err := config.RunSetup(configDir); err != nil {
+			log.Fatal(err)
+		}
 		return
 	}
 
@@ -44,15 +43,14 @@ func main() {
 		log.Fatal("DISCORD_OWNER_ID is required (run nevinho --setup or set in .env)")
 	}
 
-	providerCfg := buildProviderConfig(cfg)
-	provider := detectProvider(cfg, providerCfg)
+	provider := detectProvider(cfg)
 
 	creds, err := auth.NewStore(configDir)
 	if err != nil {
 		log.Fatalf("failed to init credentials: %v", err)
 	}
 
-	a := agent.New(provider, providerCfg, cfg)
+	a := agent.New(provider, cfg)
 	bot, err := discord.New(cfg.DiscordBotToken, cfg.DiscordOwnerID, a, creds, cfg)
 	if err != nil {
 		log.Fatalf("failed to create bot: %v", err)
@@ -72,18 +70,8 @@ func main() {
 	bot.Stop()
 }
 
-func buildProviderConfig(cfg *config.Config) agent.ProviderConfig {
-	pc := agent.ProviderConfig{
-		AnthropicKey: cfg.AnthropicAPIKey,
-		OpenAIKey:    cfg.OpenAIAPIKey,
-	}
-	if cfg.OllamaModel != "" {
-		pc.OllamaURL = "http://localhost:11434"
-	}
-	return pc
-}
-
-func detectProvider(cfg *config.Config, pc agent.ProviderConfig) llm.Provider {
+func detectProvider(cfg *config.Config) llm.Provider {
+	pc := cfg.ProviderConfig()
 	switch {
 	case cfg.OllamaModel != "":
 		logger.Info("provider: ollama (" + cfg.OllamaModel + ")")
@@ -98,53 +86,4 @@ func detectProvider(cfg *config.Config, pc agent.ProviderConfig) llm.Provider {
 		log.Fatal("no LLM provider configured (run nevinho --setup or set keys in .env)")
 		return nil
 	}
-}
-
-func runSetup(configDir string) {
-	fmt.Println("nevinho setup")
-	fmt.Println()
-
-	scanner := bufio.NewScanner(os.Stdin)
-	prompt := func(label string) string {
-		fmt.Printf("%s: ", label)
-		scanner.Scan()
-		return strings.TrimSpace(scanner.Text())
-	}
-
-	cfg, err := config.Load(configDir)
-	if err != nil {
-		log.Fatalf("failed to init config: %v", err)
-	}
-
-	cfg.DiscordBotToken = prompt("Discord bot token")
-	cfg.DiscordOwnerID = prompt("Discord owner ID")
-
-	fmt.Println()
-	fmt.Println("LLM provider:")
-	fmt.Println("  1) Anthropic (Claude)")
-	fmt.Println("  2) OpenAI (GPT)")
-	fmt.Println("  3) Ollama (local)")
-	choice := prompt("Choice [1/2/3]")
-
-	switch choice {
-	case "1":
-		cfg.AnthropicAPIKey = prompt("Anthropic API key")
-	case "2":
-		cfg.OpenAIAPIKey = prompt("OpenAI API key")
-	case "3":
-		cfg.OllamaModel = prompt("Ollama model name (e.g. llama3)")
-	}
-
-	brave := prompt("Brave Search API key (optional, press Enter to skip)")
-	if brave != "" {
-		cfg.BraveAPIKey = brave
-	}
-
-	if err := cfg.Save(); err != nil {
-		log.Fatalf("failed to save config: %v", err)
-	}
-
-	fmt.Println()
-	fmt.Printf("Config saved to %s\n", configDir)
-	fmt.Println("Run 'nevinho' to start.")
 }

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/lucasnevespereira/nevinho/config"
 	"github.com/lucasnevespereira/nevinho/llm"
 )
 
@@ -34,14 +35,16 @@ type pendingCode struct {
 
 type Registry struct {
 	mu       sync.Mutex
+	cfg      *config.Config
 	approved map[string]bool
 	pending  map[string]*Pending
 	permFile string
 }
 
-func NewRegistry() *Registry {
+func NewRegistry(cfg *config.Config) *Registry {
 	base := configDir()
 	r := &Registry{
+		cfg:      cfg,
 		approved: make(map[string]bool),
 		pending:  make(map[string]*Pending),
 		permFile: filepath.Join(base, "approved_paths.json"),

--- a/tools/web.go
+++ b/tools/web.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"slices"
 	"strings"
 	"time"
@@ -65,8 +64,8 @@ func (r *Registry) webSearch(input json.RawMessage) string {
 		return fmt.Sprintf("invalid input: %v", err)
 	}
 
-	if apiKey := os.Getenv("BRAVE_API_KEY"); apiKey != "" {
-		return searchBrave(in.Query, apiKey)
+	if r.cfg.BraveAPIKey != "" {
+		return searchBrave(in.Query, r.cfg.BraveAPIKey)
 	}
 	return searchDuckDuckGo(in.Query)
 }


### PR DESCRIPTION
## What
This PR adds centralized, encrypted configuration management with an interactive setup flow. Configuration is now encrypted and stored in `~/.config/nevinho/`, with a new `/config` command to update settings from Discord without restarting. An install script makes first-time setup painless with prompts for bot token, owner ID, and LLM provider.

## Changes
- Added `config` package for centralized configuration management with AES-256-GCM encryption
- Added `crypto` package with shared encryption utilities (extracted from auth/store.go)
- Added interactive setup flow (`config/setup.go`) invoked by `nevinho --setup`
- Added `install.sh` one-liner for easy installation with built-in setup
- Added `/config` command (slash and text) to view and update configuration from Discord
- Refactored `agent.go`: uses `config.Config` instead of inline `ProviderConfig`
- Updated tools and main entry point to load config from centralized system (env vars override encrypted config)
- Config changes are immediately applied (LLM provider reloads on key changes)
- Updated README with install instructions, new `/config` command, configuration structure, and project layout