### PR TITLE
feat: cmd and daemon service 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,23 @@ curl -sSL https://raw.githubusercontent.com/lucasnevespereira/nevinho/main/insta
 Then configure and start:
 
 ```bash
-nevinho --setup
-nevinho
+nevinho setup
+nevinho start
 ```
 
+On Linux, `start` runs as a background service (systemd). On macOS, it runs in the foreground.
+
 You can also reconfigure later from Discord with `/config`.
+
+## CLI
+
+```
+nevinho setup    configure Discord token and LLM keys
+nevinho start    start the bot
+nevinho stop     stop the bot
+nevinho logs     show live logs
+nevinho version  show version
+```
 
 ## Manual setup
 
@@ -109,7 +121,8 @@ You can also use a `.env` file in the project directory for development. Env var
 ## Project structure
 
 ```
-main.go      entry point, provider detection, setup
+main.go      entry point, CLI commands, provider detection
+service.go   systemd/launchd service management
 agent/       chat loop, tool orchestration, approval flow
 config/      encrypted configuration management
 crypto/      shared AES-256-GCM encryption

--- a/install.sh
+++ b/install.sh
@@ -53,5 +53,5 @@ fi
 
 echo ""
 echo "Done! Run:"
-echo "  nevinho --setup"
-echo "  nevinho"
+echo "  nevinho setup"
+echo "  nevinho start"

--- a/main.go
+++ b/main.go
@@ -31,22 +31,20 @@ func main() {
 	}
 
 	switch cmd {
-	case "version", "--version":
-		fmt.Println("nevinho " + version)
-	case "setup", "--setup":
+	case "setup":
 		if err := config.RunSetup(configDir); err != nil {
 			log.Fatal(err)
 		}
 	case "start":
-		if os.Getenv("INVOCATION_ID") != "" {
-			run(configDir)
-		} else {
-			startService()
-		}
+		startService(configDir)
 	case "stop":
 		stopService()
 	case "logs":
 		showLogs()
+	case "version":
+		fmt.Println("nevinho " + version)
+	case "--run":
+		run(configDir)
 	default:
 		printUsage()
 	}

--- a/main.go
+++ b/main.go
@@ -25,18 +25,34 @@ func main() {
 	home, _ := os.UserHomeDir()
 	configDir := filepath.Join(home, ".config", "nevinho")
 
-	if len(os.Args) > 1 && os.Args[1] == "--version" {
-		fmt.Println("nevinho " + version)
-		return
+	cmd := ""
+	if len(os.Args) > 1 {
+		cmd = os.Args[1]
 	}
 
-	if len(os.Args) > 1 && os.Args[1] == "--setup" {
+	switch cmd {
+	case "version", "--version":
+		fmt.Println("nevinho " + version)
+	case "setup", "--setup":
 		if err := config.RunSetup(configDir); err != nil {
 			log.Fatal(err)
 		}
-		return
+	case "start":
+		if os.Getenv("INVOCATION_ID") != "" {
+			run(configDir)
+		} else {
+			startService()
+		}
+	case "stop":
+		stopService()
+	case "logs":
+		showLogs()
+	default:
+		printUsage()
 	}
+}
 
+func run(configDir string) {
 	logger.Init()
 
 	cfg, err := config.Load(configDir)
@@ -45,10 +61,10 @@ func main() {
 	}
 
 	if cfg.DiscordBotToken == "" {
-		log.Fatal("DISCORD_BOT_TOKEN is required (run nevinho --setup or set in .env)")
+		log.Fatal("DISCORD_BOT_TOKEN is required (run nevinho setup)")
 	}
 	if cfg.DiscordOwnerID == "" {
-		log.Fatal("DISCORD_OWNER_ID is required (run nevinho --setup or set in .env)")
+		log.Fatal("DISCORD_OWNER_ID is required (run nevinho setup)")
 	}
 
 	provider := detectProvider(cfg)
@@ -91,7 +107,18 @@ func detectProvider(cfg *config.Config) llm.Provider {
 		logger.Info("provider: openai")
 		return llm.NewOpenAI(pc.OpenAIKey, "", "")
 	default:
-		log.Fatal("no LLM provider configured (run nevinho --setup or set keys in .env)")
+		log.Fatal("no LLM provider configured (run nevinho setup)")
 		return nil
 	}
+}
+
+func printUsage() {
+	fmt.Println("nevinho " + version)
+	fmt.Println()
+	fmt.Println("Usage:")
+	fmt.Println("  nevinho setup    configure Discord token and LLM keys")
+	fmt.Println("  nevinho start    start the bot")
+	fmt.Println("  nevinho stop     stop the bot")
+	fmt.Println("  nevinho logs     show live logs")
+	fmt.Println("  nevinho version  show version")
 }

--- a/service.go
+++ b/service.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+const serviceFile = "/etc/systemd/system/nevinho.service"
+
+func startService() {
+	if runtime.GOOS != "linux" || !hasSystemd() {
+		fmt.Println("No systemd found. On macOS or non-systemd Linux, run:")
+		fmt.Println("  nohup nevinho start &")
+		fmt.Println()
+		fmt.Println("Or use 'nevinho start' on a Linux server with systemd.")
+		return
+	}
+
+	if _, err := os.Stat(serviceFile); os.IsNotExist(err) {
+		installService()
+	}
+
+	runCmd("systemctl", "start", "nevinho")
+	fmt.Println("nevinho started.")
+	fmt.Println("  nevinho logs     show live logs")
+	fmt.Println("  nevinho stop     stop the bot")
+}
+
+func stopService() {
+	if !hasSystemd() {
+		fmt.Println("No systemd found. Use: pkill nevinho")
+		return
+	}
+	runCmd("systemctl", "stop", "nevinho")
+	fmt.Println("nevinho stopped.")
+}
+
+func showLogs() {
+	if !hasSystemd() {
+		fmt.Println("No systemd found. Logs are only available with systemd.")
+		return
+	}
+	cmd := exec.Command("journalctl", "-u", "nevinho", "-f", "--no-pager")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Run()
+}
+
+func installService() {
+	binPath, err := os.Executable()
+	if err != nil {
+		log.Fatalf("failed to find binary path: %v", err)
+	}
+	binPath, err = filepath.EvalSymlinks(binPath)
+	if err != nil {
+		log.Fatalf("failed to resolve binary path: %v", err)
+	}
+
+	unit := fmt.Sprintf(`[Unit]
+Description=nevinho
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=%s start
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+`, binPath)
+
+	if err := os.WriteFile(serviceFile, []byte(unit), 0644); err != nil {
+		log.Fatalf("failed to write service file (try running as root): %v", err)
+	}
+
+	runCmd("systemctl", "daemon-reload")
+	runCmd("systemctl", "enable", "nevinho")
+}
+
+func hasSystemd() bool {
+	_, err := exec.LookPath("systemctl")
+	return err == nil
+}
+
+func runCmd(name string, args ...string) {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		log.Fatalf("%s failed: %v", name, err)
+	}
+}

--- a/service.go
+++ b/service.go
@@ -11,12 +11,9 @@ import (
 
 const serviceFile = "/etc/systemd/system/nevinho.service"
 
-func startService() {
-	if runtime.GOOS != "linux" || !hasSystemd() {
-		fmt.Println("No systemd found. On macOS or non-systemd Linux, run:")
-		fmt.Println("  nohup nevinho start &")
-		fmt.Println()
-		fmt.Println("Or use 'nevinho start' on a Linux server with systemd.")
+func startService(configDir string) {
+	if runtime.GOOS != "linux" {
+		run(configDir)
 		return
 	}
 
@@ -24,24 +21,24 @@ func startService() {
 		installService()
 	}
 
-	runCmd("systemctl", "start", "nevinho")
+	systemctl("start", "nevinho")
 	fmt.Println("nevinho started.")
 	fmt.Println("  nevinho logs     show live logs")
 	fmt.Println("  nevinho stop     stop the bot")
 }
 
 func stopService() {
-	if !hasSystemd() {
-		fmt.Println("No systemd found. Use: pkill nevinho")
+	if runtime.GOOS != "linux" {
+		fmt.Println("On macOS, stop with Ctrl+C.")
 		return
 	}
-	runCmd("systemctl", "stop", "nevinho")
+	systemctl("stop", "nevinho")
 	fmt.Println("nevinho stopped.")
 }
 
 func showLogs() {
-	if !hasSystemd() {
-		fmt.Println("No systemd found. Logs are only available with systemd.")
+	if runtime.GOOS != "linux" {
+		fmt.Println("Logs are available on Linux with systemd.")
 		return
 	}
 	cmd := exec.Command("journalctl", "-u", "nevinho", "-f", "--no-pager")
@@ -66,7 +63,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=%s start
+ExecStart=%s --run
 Restart=always
 RestartSec=5
 
@@ -78,20 +75,15 @@ WantedBy=multi-user.target
 		log.Fatalf("failed to write service file (try running as root): %v", err)
 	}
 
-	runCmd("systemctl", "daemon-reload")
-	runCmd("systemctl", "enable", "nevinho")
+	systemctl("daemon-reload")
+	systemctl("enable", "nevinho")
 }
 
-func hasSystemd() bool {
-	_, err := exec.LookPath("systemctl")
-	return err == nil
-}
-
-func runCmd(name string, args ...string) {
-	cmd := exec.Command(name, args...)
+func systemctl(args ...string) {
+	cmd := exec.Command("systemctl", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		log.Fatalf("%s failed: %v", name, err)
+		log.Fatalf("systemctl %v failed: %v", args, err)
 	}
 }


### PR DESCRIPTION
## What
Refactored CLI from flag-based arguments to subcommands (setup, start, stop, logs, version) and introduced cross-platform service management. On Linux, nevinho now runs as a systemd daemon with automatic installation, log streaming, and service controls. On macOS, it runs in the foreground. The main command routing logic was simplified using a switch statement and extracted service logic into a dedicated module.

## Changes
- Changed CLI syntax from flags (`--setup`, `--version`) to subcommands (`setup`, `start`, `stop`, `logs`, `version`)
- Added `service.go` for systemd service management on Linux (daemon installation, control, and log streaming)
- Refactored `main.go` command routing from if-else chains to switch statement
- Extracted bot initialization into `run()` function, callable as `--run` for systemd
- Platform-specific behavior: Linux runs as systemd daemon, macOS runs in foreground
- Added `printUsage()` function displaying all available commands
- Updated README with new command syntax and CLI reference section
- Updated `install.sh` to output new command names
- Updated error messages to reference new command syntax