### PR TITLE
feat: upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ nevinho setup    configure Discord token and LLM keys
 nevinho start    start the bot
 nevinho stop     stop the bot
 nevinho logs     show live logs
+nevinho upgrade  update to latest version
 nevinho version  show version
 ```
 
@@ -122,7 +123,7 @@ You can also use a `.env` file in the project directory for development. Env var
 
 ```
 main.go      entry point, CLI commands, provider detection
-service.go   systemd/launchd service management
+service.go   systemd service management, self-upgrade
 agent/       chat loop, tool orchestration, approval flow
 config/      encrypted configuration management
 crypto/      shared AES-256-GCM encryption

--- a/config/setup.go
+++ b/config/setup.go
@@ -53,6 +53,6 @@ func RunSetup(configDir string) error {
 
 	fmt.Println()
 	fmt.Printf("Config saved to %s\n", configDir)
-	fmt.Println("Run 'nevinho' to start.")
+	fmt.Println("Run 'nevinho start' to start.")
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -41,6 +41,8 @@ func main() {
 		stopService()
 	case "logs":
 		showLogs()
+	case "upgrade":
+		upgrade()
 	case "version":
 		fmt.Println("nevinho " + version)
 	case "--run":
@@ -118,5 +120,6 @@ func printUsage() {
 	fmt.Println("  nevinho start    start the bot")
 	fmt.Println("  nevinho stop     stop the bot")
 	fmt.Println("  nevinho logs     show live logs")
+	fmt.Println("  nevinho upgrade  update to latest version")
 	fmt.Println("  nevinho version  show version")
 }

--- a/service.go
+++ b/service.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -77,6 +80,81 @@ WantedBy=multi-user.target
 
 	systemctl("daemon-reload")
 	systemctl("enable", "nevinho")
+}
+
+const repo = "lucasnevespereira/nevinho"
+
+func upgrade() {
+	latest, err := fetchLatestVersion()
+	if err != nil {
+		log.Fatalf("failed to check latest version: %v", err)
+	}
+
+	if latest == version {
+		fmt.Printf("Already on latest version (%s).\n", version)
+		return
+	}
+
+	fmt.Printf("Upgrading nevinho %s -> %s...\n", version, latest)
+
+	binPath, err := os.Executable()
+	if err != nil {
+		log.Fatalf("failed to find binary path: %v", err)
+	}
+	binPath, err = filepath.EvalSymlinks(binPath)
+	if err != nil {
+		log.Fatalf("failed to resolve binary path: %v", err)
+	}
+
+	binary := fmt.Sprintf("nevinho-%s-%s", runtime.GOOS, runtime.GOARCH)
+	url := fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", repo, latest, binary)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		log.Fatalf("download failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Fatalf("download failed: %s", resp.Status)
+	}
+
+	tmp := binPath + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+	if err != nil {
+		log.Fatalf("failed to write update: %v", err)
+	}
+
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		log.Fatalf("download interrupted: %v", err)
+	}
+	f.Close()
+
+	if err := os.Rename(tmp, binPath); err != nil {
+		os.Remove(tmp)
+		log.Fatalf("failed to replace binary: %v", err)
+	}
+
+	fmt.Printf("Updated to %s. Restart with 'nevinho start'.\n", latest)
+}
+
+func fetchLatestVersion() (string, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", repo)
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var release struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return "", err
+	}
+	return release.TagName, nil
 }
 
 func systemctl(args ...string) {


### PR DESCRIPTION
## What
Add a `nevinho upgrade` command that enables in-place binary updates by fetching the latest release from GitHub. Also clarify setup instructions and update documentation to reflect the new self-update capability.

## Changes
- Add `nevinho upgrade` command to check and download the latest version from GitHub releases
- Fetch latest release version from GitHub API and perform atomic binary replacement with temp file safety
- Update README to list the new `upgrade` command and clarify service.go purpose
- Fix setup message to instruct users to run `nevinho start` instead of just `nevinho`
- Add robust error handling for download failures and binary replacement