### PR TITLE
feat: implement prompt caching with cache_control

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,7 @@ Guiding principles:
 
 These are the highest-impact changes. They directly reduce token waste and make every conversation cheaper and smarter.
 
-- [ ] **Prompt caching** — Add `cache_control` breakpoints to the system prompt and tool definitions so turns 2+ reuse the cached prefix instead of re-processing ~900 tokens every call. Single biggest cost reduction available.
+- [x] **Prompt caching** — Add `cache_control` breakpoints to the system prompt and tool definitions so turns 2+ reuse the cached prefix instead of re-processing ~900 tokens every call. Single biggest cost reduction available.
 - [ ] **Cap tool results before history** — Truncate tool outputs (web_read, run_code) to ~4k chars before appending to conversation history. A single large page fetch currently bloats the entire context window for all remaining turns.
 - [ ] **Token-aware history trimming** — Replace the fixed `maxHistory = 20` message count with a token budget (~30k tokens). Count tokens approximately (`len/4`) and trim from the oldest messages first. This prevents both wasted context (20 short messages = underuse) and blown context (20 long tool results = overflow).
 - [ ] **Summarize on trim** — When messages are evicted from history, summarize them into a single "conversation so far" preamble instead of silently dropping them. The model loses less context and the user doesn't hit dead-ends from forgotten instructions.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -84,6 +84,7 @@ func (a *Agent) Chat(userID, text string) (string, error) {
 	logger.User(text)
 	start := time.Now()
 	var usage llm.Usage
+	var cacheRead int
 	var toolsUsed []string
 
 	a.appendHistory(userID, a.llm.FormatUserMessage(text))
@@ -102,11 +103,12 @@ func (a *Agent) Chat(userID, text string) (string, error) {
 
 		usage.In += resp.Usage.In
 		usage.Out += resp.Usage.Out
+		cacheRead += resp.Usage.CacheRead
 		a.history[userID] = append(a.history[userID], resp.AssistantMessage)
 
 		if len(resp.ToolCalls) == 0 {
 			a.addTokens(usage.In, usage.Out)
-			logger.Done(start, usage.In, usage.Out, toolsUsed)
+			logger.Done(start, usage.In, usage.Out, cacheRead, toolsUsed)
 			logger.Nevinho(resp.Text)
 			return resp.Text, nil
 		}
@@ -132,7 +134,7 @@ func (a *Agent) Chat(userID, text string) (string, error) {
 			p := a.tools.PendingApproval(userID)
 			reply := approvalMessage(p)
 			a.addTokens(usage.In, usage.Out)
-			logger.Done(start, usage.In, usage.Out, toolsUsed)
+			logger.Done(start, usage.In, usage.Out, cacheRead, toolsUsed)
 			logger.Nevinho(reply)
 			return reply, nil
 		}
@@ -140,7 +142,7 @@ func (a *Agent) Chat(userID, text string) (string, error) {
 
 	reply := "I hit my limit on tool calls. Try breaking it into smaller tasks."
 	a.addTokens(usage.In, usage.Out)
-	logger.Done(start, usage.In, usage.Out, toolsUsed)
+	logger.Done(start, usage.In, usage.Out, cacheRead, toolsUsed)
 	logger.Nevinho(reply)
 	return reply, nil
 }

--- a/llm/anthropic.go
+++ b/llm/anthropic.go
@@ -25,12 +25,24 @@ func NewAnthropic(apiKey, baseURL, model string) *Anthropic {
 func (a *Anthropic) Model() string { return a.model }
 
 func (a *Anthropic) Complete(req *Request) (*Response, error) {
+	tools := a.formatTools(req.Tools)
+	// Mark last tool with cache_control so the entire prefix (system + tools) is cached
+	if len(tools) > 0 {
+		tools[len(tools)-1]["cache_control"] = map[string]string{"type": "ephemeral"}
+	}
+
 	body := map[string]interface{}{
 		"model":      a.model,
 		"max_tokens": req.MaxTokens,
-		"system":     req.SystemPrompt,
-		"messages":   ensureSlice(req.Messages),
-		"tools":      a.formatTools(req.Tools),
+		"system": []map[string]interface{}{
+			{
+				"type":          "text",
+				"text":          req.SystemPrompt,
+				"cache_control": map[string]string{"type": "ephemeral"},
+			},
+		},
+		"messages": ensureSlice(req.Messages),
+		"tools":    tools,
 	}
 
 	data, err := doHTTP(a.baseURL+"/v1/messages", body, map[string]string{
@@ -46,8 +58,10 @@ func (a *Anthropic) Complete(req *Request) (*Response, error) {
 		Content    []json.RawMessage `json:"content"`
 		StopReason string            `json:"stop_reason"`
 		Usage      struct {
-			InputTokens  int `json:"input_tokens"`
-			OutputTokens int `json:"output_tokens"`
+			InputTokens              int `json:"input_tokens"`
+			OutputTokens             int `json:"output_tokens"`
+			CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+			CacheReadInputTokens     int `json:"cache_read_input_tokens"`
 		} `json:"usage"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -55,7 +69,12 @@ func (a *Anthropic) Complete(req *Request) (*Response, error) {
 	}
 
 	resp := &Response{
-		Usage: Usage{In: raw.Usage.InputTokens, Out: raw.Usage.OutputTokens},
+		Usage: Usage{
+			In:         raw.Usage.InputTokens,
+			Out:        raw.Usage.OutputTokens,
+			CacheRead:  raw.Usage.CacheReadInputTokens,
+			CacheWrite: raw.Usage.CacheCreationInputTokens,
+		},
 	}
 
 	assistantMsg, _ := json.Marshal(map[string]interface{}{

--- a/llm/provider.go
+++ b/llm/provider.go
@@ -35,8 +35,10 @@ type ToolResult struct {
 }
 
 type Usage struct {
-	In  int
-	Out int
+	In         int
+	Out        int
+	CacheRead  int
+	CacheWrite int
 }
 
 type ToolDef struct {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -31,9 +31,12 @@ func Tool(name, detail string) {
 func Err(err error)       { log.Printf("%sfail%s     %v", red, reset, err) }
 func Info(msg string)     { log.Printf("%s%s%s", dim, msg, reset) }
 
-func Done(start time.Time, tokensIn, tokensOut int, tools []string) {
+func Done(start time.Time, tokensIn, tokensOut, cacheRead int, tools []string) {
 	secs := time.Since(start).Seconds()
 	msg := fmt.Sprintf("%.1fs · %d in / %d out", secs, tokensIn, tokensOut)
+	if cacheRead > 0 {
+		msg += fmt.Sprintf(" · %d cached", cacheRead)
+	}
 	if len(tools) > 0 {
 		msg += " · " + strings.Join(tools, ", ")
 	}


### PR DESCRIPTION
## What
Implements prompt caching using Claude's cache_control feature, reducing token usage on subsequent turns by caching the system prompt and tool definitions. The system now tracks cache metrics and displays them in logs, enabling visibility into token savings from cached prefixes.

## Changes
- Add `cache_control` metadata to system prompt and last tool definition to mark them for caching
- Convert system prompt to array format to support cache_control directives
- Track cache read tokens (`CacheRead`) and cache write tokens (`CacheWrite`) from API responses
- Update `Usage` struct to include separate fields for cache read and cache write tokens
- Pass cache read token count through the agent and logger to surface cache metrics in output
- Display cached tokens in the done message when cache hits occur (e.g., "· 842 cached")
- Mark prompt caching task as completed in ROADMAP