### PR TITLE
feat: cap tool results before history

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,7 +13,7 @@ Guiding principles:
 These are the highest-impact changes. They directly reduce token waste and make every conversation cheaper and smarter.
 
 - [x] **Prompt caching** — Add `cache_control` breakpoints to the system prompt and tool definitions so turns 2+ reuse the cached prefix instead of re-processing ~900 tokens every call. Single biggest cost reduction available.
-- [ ] **Cap tool results before history** — Truncate tool outputs (web_read, run_code) to ~4k chars before appending to conversation history. A single large page fetch currently bloats the entire context window for all remaining turns.
+- [x] **Cap tool results before history** — Truncate tool outputs to ~4k chars before appending to conversation history. A single large page fetch currently bloats the entire context window for all remaining turns.
 - [ ] **Token-aware history trimming** — Replace the fixed `maxHistory = 20` message count with a token budget (~30k tokens). Count tokens approximately (`len/4`) and trim from the oldest messages first. This prevents both wasted context (20 short messages = underuse) and blown context (20 long tool results = overflow).
 - [ ] **Summarize on trim** — When messages are evicted from history, summarize them into a single "conversation so far" preamble instead of silently dropping them. The model loses less context and the user doesn't hit dead-ends from forgotten instructions.
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -17,7 +17,8 @@ import (
 const (
 	maxTokens  = 4096
 	maxLoops   = 10
-	maxHistory = 20
+	maxHistory    = 20
+	maxToolResult = 4000
 
 	systemPrompt = `You are nevinho, a personal AI assistant on Discord. You help users by running commands, searching the web, and managing files.
 
@@ -119,6 +120,9 @@ func (a *Agent) Chat(userID, text string) (string, error) {
 			toolsUsed = append(toolsUsed, tc.Name)
 			logger.Tool(tc.Name, toolDetail(tc.Name, tc.Input))
 			output := a.executeTool(tc.Name, tc.Input, userID)
+			if len(output) > maxToolResult {
+				output = output[:maxToolResult] + "\n...(truncated)"
+			}
 			results = append(results, llm.ToolResult{ID: tc.ID, Output: output})
 			if strings.HasPrefix(output, "NEEDS_APPROVAL:") {
 				needsApproval = true

--- a/tools/bash.go
+++ b/tools/bash.go
@@ -113,8 +113,8 @@ func (r *Registry) executeBash(command string) string {
 		result += "\n" + err.Error()
 	}
 
-	if len(result) > 5000 {
-		result = result[:5000] + "\n...(truncated)"
+	if len(result) > maxResponseLen {
+		result = result[:maxResponseLen] + "\n...(truncated)"
 	}
 
 	if result == "" {

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -12,7 +12,7 @@ import (
 	"github.com/lucasnevespereira/nevinho/llm"
 )
 
-const maxResponseLen = 10000
+const maxResponseLen = 8000
 
 func configDir() string {
 	home, err := os.UserHomeDir()


### PR DESCRIPTION
## What
Implements tool result truncation before appending to conversation history, preventing large tool outputs from bloating the context window for all subsequent turns. Results are now capped at ~4k characters, reducing token waste while preserving enough output for meaningful context.

## Changes
- Add `maxToolResult` constant (4000 chars) to cap tool outputs before adding to history
- Truncate tool results in Agent.Chat after execution but before appending to conversation
- Consolidate bash tool truncation to use the shared `maxResponseLen` constant
- Reduce `maxResponseLen` from 10000 to 8000 chars for consistency across tool outputs
- Mark "Cap tool results before history" as complete in ROADMAP.md