### PR TITLE
feat(agent): implement token-aware history trimming

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ These are the highest-impact changes. They directly reduce token waste and make 
 
 - [x] **Prompt caching** — Add `cache_control` breakpoints to the system prompt and tool definitions so turns 2+ reuse the cached prefix instead of re-processing ~900 tokens every call. Single biggest cost reduction available.
 - [x] **Cap tool results before history** — Truncate tool outputs to ~4k chars before appending to conversation history. A single large page fetch currently bloats the entire context window for all remaining turns.
-- [ ] **Token-aware history trimming** — Replace the fixed `maxHistory = 20` message count with a token budget (~30k tokens). Count tokens approximately (`len/4`) and trim from the oldest messages first. This prevents both wasted context (20 short messages = underuse) and blown context (20 long tool results = overflow).
+- [x] **Token-aware history trimming** — Replace the fixed `maxHistory = 20` message count with a token budget (~30k tokens). Count tokens approximately (`len/4`) and trim from the oldest messages first. This prevents both wasted context (20 short messages = underuse) and blown context (20 long tool results = overflow).
 - [ ] **Summarize on trim** — When messages are evicted from history, summarize them into a single "conversation so far" preamble instead of silently dropping them. The model loses less context and the user doesn't hit dead-ends from forgotten instructions.
 
 ## P1: Observability & Cost Tracking

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -18,7 +18,7 @@ import (
 const (
 	maxTokens  = 4096
 	maxLoops   = 10
-	maxHistory    = 20
+	maxContextTokens = 30_000
 	maxToolResult = 4000
 
 	systemPrompt = `You are nevinho, a personal AI assistant running on the user's VPS. The user talks to you from Discord on their phone. They have no terminal access. You are their only way to interact with this machine.
@@ -133,7 +133,7 @@ func (a *Agent) Chat(userID, text string) (string, error) {
 		usage.In += resp.Usage.In
 		usage.Out += resp.Usage.Out
 		cacheRead += resp.Usage.CacheRead
-		a.history[userID] = append(a.history[userID], resp.AssistantMessage)
+		a.appendHistory(userID, resp.AssistantMessage)
 
 		if len(resp.ToolCalls) == 0 {
 			a.addTokens(usage.In, usage.Out)
@@ -158,9 +158,7 @@ func (a *Agent) Chat(userID, text string) (string, error) {
 		}
 
 		// The API requires tool results after every assistant message with tool_use
-		for _, msg := range a.llm.FormatToolResults(results) {
-			a.history[userID] = append(a.history[userID], msg)
-		}
+		a.appendHistory(userID, a.llm.FormatToolResults(results)...)
 
 		if needsApproval {
 			p := a.tools.PendingApproval(userID)
@@ -298,10 +296,10 @@ func (a *Agent) getUserLock(userID string) *sync.Mutex {
 	return a.userLock[userID]
 }
 
-func (a *Agent) appendHistory(userID string, msg json.RawMessage) {
-	a.history[userID] = append(a.history[userID], msg)
-	if len(a.history[userID]) > maxHistory {
-		a.history[userID] = trimHistory(a.history[userID], maxHistory)
+func (a *Agent) appendHistory(userID string, msgs ...json.RawMessage) {
+	a.history[userID] = append(a.history[userID], msgs...)
+	if estimateTokens(a.history[userID]) > maxContextTokens {
+		a.history[userID] = trimHistoryByTokens(a.history[userID], maxContextTokens)
 	}
 }
 
@@ -342,12 +340,24 @@ func formatDuration(d time.Duration) string {
 	return fmt.Sprintf("%ds", s)
 }
 
-func trimHistory(msgs []json.RawMessage, maxLen int) []json.RawMessage {
-	if len(msgs) <= maxLen {
+func estimateTokens(msgs []json.RawMessage) int {
+	total := 0
+	for _, m := range msgs {
+		total += len(m) / 4
+	}
+	return total
+}
+
+func trimHistoryByTokens(msgs []json.RawMessage, budget int) []json.RawMessage {
+	if estimateTokens(msgs) <= budget {
 		return msgs
 	}
-	start := len(msgs) - maxLen
-	// Walk forward to find a plain user message
+	// Find earliest index where remaining messages fit in budget
+	start := 0
+	for start < len(msgs) && estimateTokens(msgs[start:]) > budget {
+		start++
+	}
+	// Walk forward to find a clean boundary (plain user message)
 	for start < len(msgs) {
 		var peek struct {
 			Role    string          `json:"role"`


### PR DESCRIPTION
## What
Implemented token-aware conversation history trimming to replace the fixed message count limit. The agent now maintains approximately 30,000 tokens of history by estimating token counts (length/4) and trimming from the oldest messages when budget is exceeded, preventing both underutilization of short conversations and context overflow from long tool results.

## Changes
- Replaced fixed `maxHistory = 20` with `maxContextTokens = 30_000` token budget
- Added `estimateTokens()` function that approximates token count as message length divided by 4
- Renamed `trimHistory()` to `trimHistoryByTokens()` to trim based on token budget instead of message count
- Updated `appendHistory()` to accept variadic message slice for cleaner batch appending
- Changed history trimming logic to walk forward from oldest messages, keeping those that fit within token budget
- Updated call sites to use variadic `appendHistory()` for tool results
- Marked roadmap task as completed