### PR TITLE
feat(agent): summarize and prepend on history trim

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,306 @@
+# Architecture
+
+How nevinho processes a message, manages context, and keeps token spend under control.
+
+---
+
+## System Overview
+
+```
+Discord DM                  nevinho (VPS)                    LLM API
+----------                  -------------                    -------
+                     +---------------------------+
+  user msg -------->|  Discord Bot               |
+                    |  - auth (owner-only)       |
+                    |  - slash commands           |
+                    |  - typing indicator (8s)    |
+                    +------------|---------------+
+                                 |
+                                 v
+                    +---------------------------+
+                    |  Agent.Chat()              |
+                    |  - per-user lock           |
+                    |  - cancellable context     |
+                    |  - approval gate           |
+                    |  - agentic loop (max 10)   |
+                    +------------|---------------+
+                                 |
+                    +------------|---------------+
+                    |  Context Window            |
+                    |  ~~~~~~~~~~~~~             |
+                    |  [system prompt] (cached)  |
+                    |  [tool defs]     (cached)  |
+                    |  [summary preamble]        |
+                    |  [user/assistant/tool msgs]|
+                    |                            |
+                    |  Budget: 30k tokens        |
+                    +------------|---------------+
+                                 |
+                                 v
+                    +---------------------------+
+                    |  LLM Provider              |
+                    |  - Anthropic / OpenAI      |   ------>  API
+                    |  - prompt caching          |  <------  response
+                    |  - raw HTTP, no SDKs       |
+                    +---------------------------+
+                                 |
+                                 v
+                    +---------------------------+
+                    |  Tool Registry             |
+                    |  - bash (2m timeout)       |
+                    |  - web_search / web_read   |
+                    |  - file_read / file_write  |
+                    |  - danger detection        |
+                    |  - approval flow           |
+                    +---------------------------+
+```
+
+---
+
+## The Agentic Loop
+
+This is the core of `agent.Chat()`. One user message can trigger multiple LLM calls as the model uses tools.
+
+```
+User sends message
+    |
+    v
+appendHistory(user message)
+    |--- budget exceeded? --> trim oldest, summarize evicted
+    |
+    v
++--[LOOP start, max 10 iterations]--+
+|                                     |
+|   Check ctx cancelled? --> return   |
+|           |                         |
+|           v                         |
+|   llm.Complete(                     |
+|     system prompt,                  |
+|     history,                        |
+|     tool defs                       |
+|   )                                 |
+|           |                         |
+|           v                         |
+|   appendHistory(assistant reply)    |
+|           |                         |
+|           v                         |
+|   No tool calls? --> return text    |
+|           |                         |
+|   Has tool calls:                   |
+|     for each tool call:             |
+|       - execute tool                |
+|       - cap result at 4KB           |
+|       - check if needs approval     |
+|           |                         |
+|           v                         |
+|   appendHistory(tool results)       |
+|           |                         |
+|           v                         |
+|   Needs approval? --> return early  |
+|           |                         |
+|   [next iteration] -----> LOOP      |
+|                                     |
++-------------------------------------+
+```
+
+---
+
+## Context Engineering
+
+Every token entering the context window must earn its place. Four mechanisms enforce this:
+
+### 1. Prompt Caching
+
+The system prompt and tool definitions are marked with `cache_control: ephemeral` so the API caches them. Turns 2+ reuse the cached prefix instead of re-tokenizing ~900 tokens.
+
+```
+Request to Anthropic API:
+  system: [{text: "...", cache_control: {type: "ephemeral"}}]
+  tools:  [..., {last_tool, cache_control: {type: "ephemeral"}}]
+```
+
+Savings show up as `cache_read_input_tokens` in the response.
+
+### 2. Tool Result Capping
+
+Every tool output is truncated before it enters history:
+
+```
+Tool layer:     bash output capped at 8KB
+                file_read capped at 8KB
+                web_read capped at 8KB
+
+Agent layer:    all tool results capped at 4KB before history
+```
+
+This prevents a single `cat` or page fetch from bloating every future turn.
+
+### 3. Token-Aware History Trimming
+
+History is bounded by a **token budget** (30k tokens), not a message count.
+
+```
+appendHistory(new message)
+    |
+    v
+estimateTokens(history) > 30,000?
+    |
+    no --> done
+    |
+    yes --> trimHistoryByTokens:
+              1. Find earliest index where remaining msgs fit budget
+              2. Walk forward to clean boundary:
+                 - skip orphaned tool results
+                 - skip orphaned assistant messages
+                 - skip tool_use array messages
+                 - land on a plain user message
+              3. Return msgs[start:]
+```
+
+Token estimation: `len(json_bytes) / 4` per message. Rough but effective. Being off by 20% just means trimming slightly earlier or later.
+
+Why token budget over message count:
+- 20 short messages = ~2k tokens (wastes 90% of the window)
+- 20 messages with tool results = ~60k tokens (blows the window)
+- Token budget adapts to actual content size
+
+### 4. Summarize on Trim
+
+When messages are evicted from history, they don't just disappear. The agent asks the LLM to summarize them:
+
+```
+Evicted messages (> 2 messages):
+    |
+    v
+flattenMessages:
+    "user: deploy the app to prod..."
+    "assistant: [tool interaction]"
+    "user: check if nginx is running..."
+    |
+    v
+llm.Complete(
+    system: "Summarize in 2-3 sentences..."
+    max_tokens: 200
+)
+    |
+    v
+Prepend to history:
+    [Conversation so far: User asked to deploy the app
+     and check nginx. Both tasks completed successfully.]
+```
+
+This costs ~200 output tokens once, but preserves context that would otherwise be lost forever. The model no longer hits dead-ends from forgotten instructions.
+
+---
+
+## What Enters the Context Window
+
+On each LLM call, the context window contains:
+
+```
++--------------------------------------------------+
+| System Prompt              ~220 tokens   (cached) |
+| Tool Definitions           ~680 tokens   (cached) |
+|--------------------------------------------------|
+| [Summary preamble]         ~50-100 tokens         |
+| User message 1             variable               |
+| Assistant reply 1          variable               |
+| User message 2 (tools)     variable               |
+| Tool results               variable (capped 4KB)  |
+| ...                                               |
+| Latest user message        variable               |
+|--------------------------------------------------|
+| Total budget:              ~30,000 tokens          |
+| Max output:                4,096 tokens            |
++--------------------------------------------------+
+```
+
+The cached prefix (~900 tokens) is essentially free after the first turn. The remaining ~29k is the sliding window of conversation.
+
+---
+
+## Concurrency Model
+
+```
+Agent (shared)
+  |
+  +-- mu (sync.Mutex): protects history, userLock, cancelFn maps
+  |
+  +-- userLock[userID]: one mutex per user, serializes Chat() calls
+  |
+  +-- cancelFn[userID]: per-user cancellation via context
+```
+
+- Each user gets their own lock. Two users can chat simultaneously.
+- One user's messages are serialized. No interleaving within a conversation.
+- `/cancel` calls `cancelFn[userID]()`, checked at each loop iteration.
+
+---
+
+## Safety & Approval Flow
+
+```
+Tool execution
+    |
+    v
+Dangerous command? (rm, sudo, curl|, etc.)
+    |--- yes --> store pending approval
+    |            return "NEEDS_APPROVAL: ..."
+    |            agent pauses, asks user
+    |            user replies "yes"
+    |            next Chat() call detects approval
+    |            executes pending command
+    |
+    |--- no --> execute normally
+    |
+    v
+Writing to new path?
+    |--- yes --> same approval flow
+    |--- no (approved path) --> execute
+```
+
+Approved paths persist across sessions in `~/.config/nevinho/approved_paths.json`.
+
+---
+
+## Constants
+
+| Name | Value | Purpose |
+|------|-------|---------|
+| `maxTokens` | 4,096 | Max output tokens per LLM call |
+| `maxLoops` | 10 | Max tool-call iterations per Chat() |
+| `maxContextTokens` | 30,000 | Token budget for conversation history |
+| `maxToolResult` | 4,000 | Max bytes per tool result in history |
+| `maxResponseLen` | 8,000 | Max bytes per tool output (tool layer) |
+| `maxFileSize` | 100 KB | Max file size for file_read |
+| `bashTimeout` | 120s | Bash command timeout |
+| `httpTimeout` | 15s | HTTP request timeout |
+
+---
+
+## Package Map
+
+```
+nevinho/
+  main.go              CLI entry point
+  agent/
+    agent.go           Chat loop, context management, history trimming
+  llm/
+    provider.go        Provider interface (Complete, Format*)
+    anthropic.go       Anthropic API + prompt caching
+    openai.go          OpenAI API (+ Ollama via compatible endpoint)
+    http.go            Shared HTTP client
+  tools/
+    registry.go        Tool dispatch, approval flow, path permissions
+    bash.go            Shell execution, danger detection
+    file.go            File read/write with sandboxing
+    web.go             Web search (Brave/DDG) and page fetch
+  discord/
+    bot.go             Discord session, message handling, slash commands
+  config/
+    config.go          Encrypted config with env/file/runtime layers
+  crypto/
+    crypto.go          AES-256-GCM encryption
+  logger/
+    logger.go          Colored terminal output
+```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ These are the highest-impact changes. They directly reduce token waste and make 
 - [x] **Prompt caching** — Add `cache_control` breakpoints to the system prompt and tool definitions so turns 2+ reuse the cached prefix instead of re-processing ~900 tokens every call. Single biggest cost reduction available.
 - [x] **Cap tool results before history** — Truncate tool outputs to ~4k chars before appending to conversation history. A single large page fetch currently bloats the entire context window for all remaining turns.
 - [x] **Token-aware history trimming** — Replace the fixed `maxHistory = 20` message count with a token budget (~30k tokens). Count tokens approximately (`len/4`) and trim from the oldest messages first. This prevents both wasted context (20 short messages = underuse) and blown context (20 long tool results = overflow).
-- [ ] **Summarize on trim** — When messages are evicted from history, summarize them into a single "conversation so far" preamble instead of silently dropping them. The model loses less context and the user doesn't hit dead-ends from forgotten instructions.
+- [x] **Summarize on trim** — When messages are evicted from history, summarize them into a single "conversation so far" preamble instead of silently dropping them. The model loses less context and the user doesn't hit dead-ends from forgotten instructions.
 
 ## P1: Observability & Cost Tracking
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -113,7 +113,9 @@ func (a *Agent) Chat(userID, text string) (string, error) {
 	var cacheRead int
 	var toolsUsed []string
 
-	a.appendHistory(userID, a.llm.FormatUserMessage(text))
+	if evicted := a.appendHistory(userID, a.llm.FormatUserMessage(text)); len(evicted) > 2 {
+		a.summarizeAndPrepend(userID, evicted)
+	}
 
 	for range maxLoops {
 		if ctx.Err() != nil {
@@ -296,11 +298,17 @@ func (a *Agent) getUserLock(userID string) *sync.Mutex {
 	return a.userLock[userID]
 }
 
-func (a *Agent) appendHistory(userID string, msgs ...json.RawMessage) {
+func (a *Agent) appendHistory(userID string, msgs ...json.RawMessage) (evicted []json.RawMessage) {
 	a.history[userID] = append(a.history[userID], msgs...)
-	if estimateTokens(a.history[userID]) > maxContextTokens {
-		a.history[userID] = trimHistoryByTokens(a.history[userID], maxContextTokens)
+	if estimateTokens(a.history[userID]) <= maxContextTokens {
+		return nil
 	}
+	trimmed := trimHistoryByTokens(a.history[userID], maxContextTokens)
+	evictedCount := len(a.history[userID]) - len(trimmed)
+	evicted = make([]json.RawMessage, evictedCount)
+	copy(evicted, a.history[userID][:evictedCount])
+	a.history[userID] = trimmed
+	return evicted
 }
 
 func (a *Agent) executeTool(name string, input json.RawMessage, userID string) (output string) {
@@ -338,6 +346,54 @@ func formatDuration(d time.Duration) string {
 		return fmt.Sprintf("%dm %ds", m, s)
 	}
 	return fmt.Sprintf("%ds", s)
+}
+
+// summarizeAndPrepend asks the LLM to summarize evicted messages and
+// inserts the summary as the first message in the user's history.
+func (a *Agent) summarizeAndPrepend(userID string, evicted []json.RawMessage) {
+	flat := flattenMessages(evicted)
+	if flat == "" {
+		return
+	}
+	resp, err := a.llm.Complete(&llm.Request{
+		SystemPrompt: "Summarize this conversation excerpt in 2-3 sentences. Focus on what was asked, what was done, and important outcomes.",
+		Messages:     []json.RawMessage{a.llm.FormatUserMessage(flat)},
+		MaxTokens:    200,
+	})
+	if err != nil {
+		logger.Err(fmt.Errorf("summary failed: %w", err))
+		return
+	}
+	if resp.Text == "" {
+		return
+	}
+	preamble := a.llm.FormatUserMessage("[Conversation so far: " + resp.Text + "]")
+	a.history[userID] = append([]json.RawMessage{preamble}, a.history[userID]...)
+}
+
+func flattenMessages(msgs []json.RawMessage) string {
+	var sb strings.Builder
+	for _, m := range msgs {
+		var peek struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		}
+		if err := json.Unmarshal(m, &peek); err != nil {
+			continue
+		}
+		// Try to extract string content
+		var text string
+		if err := json.Unmarshal(peek.Content, &text); err == nil {
+			runes := []rune(text)
+			if len(runes) > 200 {
+				text = string(runes[:200]) + "..."
+			}
+			fmt.Fprintf(&sb, "%s: %s\n", peek.Role, text)
+		} else {
+			fmt.Fprintf(&sb, "%s: [tool interaction]\n", peek.Role)
+		}
+	}
+	return sb.String()
 }
 
 func estimateTokens(msgs []json.RawMessage) int {


### PR DESCRIPTION
## What

Implement automatic summarization of evicted conversation history. When the context window reaches capacity and older messages are trimmed, the agent now summarizes them into a brief preamble instead of silently discarding the context. This preserves conversation continuity and prevents the model from losing important instructions or prior work, while keeping token overhead minimal (~200 tokens per trim).

## Changes

- Add `summarizeAndPrepend()` to generate a concise summary of evicted messages via LLM and prepend it to history
- Modify `appendHistory()` to track and return evicted messages, enabling summaries only when meaningful (2+ messages)
- Add `flattenMessages()` helper to convert message JSON into readable text with truncation for large outputs- Update ROADMAP.md to mark "Summarize on trim" as complete
- Add comprehensive ARCHITECTURE.md documenting the agentic loop, context engineering, history trimming, concurrency model, and component structure