### PR TITLE
fix: edit and read tools

### DIFF
--- a/tools/file.go
+++ b/tools/file.go
@@ -9,7 +9,10 @@ import (
 	"strings"
 )
 
-const maxFileSize = 100 * 1024 // 100KB
+const (
+	maxFileSize  = 100 * 1024 // 100KB
+	maxReadLines = 200        // max lines returned in one read
+)
 
 type fileReadInput struct {
 	Path   string `json:"path"`
@@ -39,37 +42,43 @@ func (r *Registry) fileRead(input json.RawMessage, userID string) string {
 	content := string(data)
 	totalLines := strings.Count(content, "\n") + 1
 
-	// Paginated read
-	if in.Offset > 0 || in.Limit > 0 {
-		lines := strings.Split(content, "\n")
+	lines := strings.Split(content, "\n")
 
-		start := 0
-		if in.Offset > 0 {
-			start = in.Offset - 1
-		}
-		if start >= totalLines {
-			return fmt.Sprintf("offset %d exceeds file length (%d lines)", in.Offset, totalLines)
-		}
-
-		end := totalLines
-		if in.Limit > 0 && start+in.Limit < totalLines {
-			end = start + in.Limit
-		}
-
-		chunk := strings.Join(lines[start:end], "\n")
-		return fmt.Sprintf("[lines %d-%d of %d]\n%s", start+1, end, totalLines, chunk)
+	start := 0
+	if in.Offset > 0 {
+		start = in.Offset - 1
+	}
+	if start >= totalLines {
+		return fmt.Sprintf("offset %d exceeds file length (%d lines)", in.Offset, totalLines)
 	}
 
-	// Full read with truncation
-	display := content
-	if len(display) > maxResponseLen {
-		display = display[:maxResponseLen]
-		if idx := strings.LastIndex(display, "\n"); idx != -1 {
-			display = display[:idx]
-		}
+	limit := in.Limit
+	if limit <= 0 {
+		limit = maxReadLines
 	}
 
-	return fmt.Sprintf("[%s, %d lines]\n%s", in.Path, totalLines, display)
+	end := start + limit
+	if end > totalLines {
+		end = totalLines
+	}
+
+	chunk := strings.Join(lines[start:end], "\n")
+
+	// Truncate by bytes if still too large
+	if len(chunk) > maxResponseLen {
+		chunk = chunk[:maxResponseLen]
+		if idx := strings.LastIndex(chunk, "\n"); idx != -1 {
+			chunk = chunk[:idx]
+		}
+		end = start + strings.Count(chunk, "\n") + 1
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "[%s, lines %d-%d of %d]\n%s", in.Path, start+1, end, totalLines, chunk)
+	if end < totalLines {
+		fmt.Fprintf(&sb, "\n[truncated, use offset=%d to continue]", end+1)
+	}
+	return sb.String()
 }
 
 type fileWriteInput struct {

--- a/tools/file.go
+++ b/tools/file.go
@@ -37,9 +37,9 @@ func (r *Registry) fileRead(input json.RawMessage, userID string) string {
 	}
 
 	content := string(data)
-	lang := langFromExt(resolved)
 	totalLines := strings.Count(content, "\n") + 1
 
+	// Paginated read
 	if in.Offset > 0 || in.Limit > 0 {
 		lines := strings.Split(content, "\n")
 
@@ -57,11 +57,10 @@ func (r *Registry) fileRead(input json.RawMessage, userID string) string {
 		}
 
 		chunk := strings.Join(lines[start:end], "\n")
-		r.QueueFileDisplay(userID, in.Path, lang, chunk)
-		return fmt.Sprintf("lines %d-%d of %d shown to user", start+1, end, totalLines)
+		return fmt.Sprintf("[lines %d-%d of %d]\n%s", start+1, end, totalLines, chunk)
 	}
 
-	// Full read with truncation.
+	// Full read with truncation
 	display := content
 	if len(display) > maxResponseLen {
 		display = display[:maxResponseLen]
@@ -70,8 +69,7 @@ func (r *Registry) fileRead(input json.RawMessage, userID string) string {
 		}
 	}
 
-	r.QueueFileDisplay(userID, in.Path, lang, display)
-	return fmt.Sprintf("%s (%d lines) shown to user", in.Path, totalLines)
+	return fmt.Sprintf("[%s, %d lines]\n%s", in.Path, totalLines, display)
 }
 
 type fileWriteInput struct {
@@ -463,29 +461,6 @@ func lineIndexAt(content string, byteOffset int) int {
 		byteOffset = len(content)
 	}
 	return strings.Count(content[:byteOffset], "\n")
-}
-
-func langFromExt(path string) string {
-	base := strings.ToLower(filepath.Base(path))
-	switch base {
-	case "dockerfile":
-		return "dockerfile"
-	case "makefile":
-		return "makefile"
-	}
-	ext := strings.TrimPrefix(filepath.Ext(base), ".")
-	switch ext {
-	case "sh", "zsh":
-		return "bash"
-	case "yml":
-		return "yaml"
-	case "mod":
-		return "go"
-	case "":
-		return ""
-	default:
-		return ext
-	}
 }
 
 func resolvePath(path, _ string) (string, error) {

--- a/tools/file_test.go
+++ b/tools/file_test.go
@@ -84,18 +84,17 @@ func TestFileReadPagination(t *testing.T) {
 	}
 
 	tests := []struct {
-		name            string
-		offset          int
-		limit           int
-		summaryContains string
-		displayContains string
-		displayExcludes string
+		name     string
+		offset   int
+		limit    int
+		contains string
+		excludes string
 	}{
-		{"full read", 0, 0, "shown to user", "line 1", ""},
-		{"offset only", 5, 0, "lines 5-10", "line 5", "line 4"},
-		{"limit only", 0, 3, "lines 1-3", "line 1", "line 4"},
-		{"offset and limit", 3, 2, "lines 3-4", "line 3", "line 1"},
-		{"offset beyond end", 99, 0, "offset 99 exceeds", "", ""},
+		{"full read", 0, 0, "line 1", ""},
+		{"offset only", 5, 0, "line 5", "line 4"},
+		{"limit only", 0, 3, "line 1", "line 4"},
+		{"offset and limit", 3, 2, "line 3", "line 1"},
+		{"offset beyond end", 99, 0, "offset 99 exceeds", ""},
 	}
 
 	for _, tt := range tests {
@@ -106,20 +105,11 @@ func TestFileReadPagination(t *testing.T) {
 				"limit":  tt.limit,
 			})
 			got := r.fileRead(input, "u1")
-			if !strings.Contains(got, tt.summaryContains) {
-				t.Errorf("summary missing %q\ngot: %s", tt.summaryContains, got)
+			if !strings.Contains(got, tt.contains) {
+				t.Errorf("expected %q in result\ngot: %s", tt.contains, got)
 			}
-			displays := r.DrainFileDisplays("u1")
-			if tt.displayContains != "" {
-				if len(displays) == 0 {
-					t.Fatal("expected file display but got none")
-				}
-				if !strings.Contains(displays[0].Content, tt.displayContains) {
-					t.Errorf("display missing %q", tt.displayContains)
-				}
-				if tt.displayExcludes != "" && strings.Contains(displays[0].Content, tt.displayExcludes) {
-					t.Errorf("display should not contain %q", tt.displayExcludes)
-				}
+			if tt.excludes != "" && strings.Contains(got, tt.excludes) {
+				t.Errorf("should not contain %q\ngot: %s", tt.excludes, got)
 			}
 		})
 	}

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -107,12 +107,12 @@ Guidelines:
 		},
 		{
 			Name: "file_read",
-			Description: `Read a file's contents with line numbers. For large files use offset and limit to paginate.
+			Description: `Read a file's contents. Output is truncated to 200 lines. Use offset to continue reading large files.
 Guidelines:
 - Always read a file before editing it. Copy old_text exactly from the read output.
-- Use offset (1-indexed) and limit to read specific sections of large files.
-- The response header shows which lines are returned and the total line count.`,
-			Schema: `{"type":"object","properties":{"path":{"type":"string","description":"Absolute file path"},"offset":{"type":"integer","description":"Line number to start from (1-indexed)"},"limit":{"type":"integer","description":"Max lines to return"}},"required":["path"]}`,
+- If the output says "truncated, use offset=N to continue", call file_read again with that offset.
+- The header shows [path, lines X-Y of Z] so you know where you are in the file.`,
+			Schema: `{"type":"object","properties":{"path":{"type":"string","description":"Absolute file path"},"offset":{"type":"integer","description":"Line number to start from (1-indexed)"},"limit":{"type":"integer","description":"Max lines to return (default 200)"}},"required":["path"]}`,
 		},
 		{
 			Name: "file_write",


### PR DESCRIPTION
## What
This refactoring simplifies file reading by inlining file content directly in the response instead of using a separate display queue. All reads now have a consistent 200-line default limit, with pagination guidance for larger files. The logic unifies previous separate code paths and removes unused language-detection code.

## Changes
- Add `maxReadLines = 200` constant to enforce a default read limit on all file reads
- Unify file reading logic: always split content into lines and apply the limit (eliminates separate code paths for offset/limit vs full reads)
- Inline file content in response with header format `[path, lines X-Y of Z]` instead of queuing separate displays
- Add truncation hint `[truncated, use offset=N to continue]` when more lines remain beyond the limit
- Remove unused `langFromExt()` function (no longer needed since language detection is unused)
- Update `file_read` tool description and schema to clarify the 200-line default and pagination behavior
- Simplify test assertions to check response content directly, removing separate summary and display queue checks