### PR TITLE
feat: caveman response style

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -44,14 +44,7 @@ Guidelines:
 - When the user asks to see a diff, run bash with "git diff". Don't dump the whole file.
 - Bash is non-interactive. Use -y flags. If credentials are needed, ask the user.
 - When asked to build a full project, write a plan.md first. Check it before each step.
-
-Response style:
-- The user reads on a phone. Avoid wide tables and long horizontal lines.
-- Drop filler: articles (a, the), hedges (just, really, basically), pleasantries, qualifiers.
-- Use fragments, not full sentences.
-- Pattern: "[thing] [action] [reason]. [next step]."
-- Abbreviate freely in prose.
-- Preserve code, URLs, commands, paths, and file contents exactly. Never abbreviate inside code blocks.`
+- The user reads on Discord, often on a phone. Keep answers compact. Avoid wide tables and long horizontal lines.`
 )
 
 type Agent struct {
@@ -152,6 +145,7 @@ func (a *Agent) Chat(userID, text string, isVoice bool) (string, error) {
 	if mem := memory.Load(a.cfg.Dir()); mem != "" {
 		prompt += "\n\n[Memory]\nThe user has told you these things. Follow them:\n" + mem
 	}
+	prompt += a.cfg.CavemanPrompt()
 
 	if evicted := a.appendHistory(userID, a.llm.FormatUserMessage(text)); len(evicted) > 2 {
 		a.summarizeAndPrepend(userID, evicted)

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	OllamaModel     string `json:"ollama_model"`
 	BraveAPIKey     string `json:"brave_api_key"`
 	Model           string `json:"model"`
+	Caveman         string `json:"caveman"`
 }
 
 // keymap maps user-facing key names to struct field pointers.
@@ -35,6 +36,7 @@ func (c *Config) keymap() map[string]*string {
 		"OLLAMA_MODEL":      &c.OllamaModel,
 		"BRAVE_API_KEY":     &c.BraveAPIKey,
 		"MODEL":             &c.Model,
+		"CAVEMAN":           &c.Caveman,
 	}
 }
 
@@ -103,6 +105,16 @@ func (c *Config) Get(key string) (string, error) {
 }
 
 func (c *Config) Set(key, value string) error {
+	if key == "CAVEMAN" {
+		switch value {
+		case "", "off", "lite", "full", "ultra":
+		default:
+			return fmt.Errorf("CAVEMAN must be one of: off, lite, full, ultra")
+		}
+		if value == "off" {
+			value = ""
+		}
+	}
 	c.mu.Lock()
 	field, ok := c.keymap()[key]
 	if !ok {
@@ -125,7 +137,7 @@ func (c *Config) Keys() []KeyStatus {
 	order := []string{
 		"DISCORD_BOT_TOKEN", "DISCORD_OWNER_ID",
 		"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OLLAMA_MODEL",
-		"BRAVE_API_KEY", "MODEL",
+		"BRAVE_API_KEY", "MODEL", "CAVEMAN",
 	}
 
 	km := c.keymap()
@@ -144,6 +156,40 @@ func (c *Config) Keys() []KeyStatus {
 }
 
 func (c *Config) Dir() string { return c.dir }
+
+// CavemanPrompt returns the caveman prompt block to append to the system prompt,
+// based on the current CAVEMAN config value. Returns "" when disabled.
+func (c *Config) CavemanPrompt() string {
+	c.mu.RLock()
+	mode := c.Caveman
+	c.mu.RUnlock()
+
+	switch mode {
+	case "lite":
+		return `
+Response style:
+- No filler, no hedging, no pleasantries.
+- Keep articles and full sentences. Professional but tight.
+- Preserve code, URLs, commands, paths, and file contents exactly.`
+	case "full":
+		return `
+Response style:
+- Drop filler: articles (a, the), hedges (just, really, basically), pleasantries, qualifiers.
+- Use fragments, not full sentences.
+- Pattern: "[thing] [action] [reason]. [next step]."
+- Abbreviate freely in prose.
+- Preserve code, URLs, commands, paths, and file contents exactly. Never abbreviate inside code blocks.`
+	case "ultra":
+		return `
+Response style:
+- Drop articles, conjunctions, hedges, pleasantries.
+- Abbreviate: DB, auth, config, req, res, fn, impl, repo, env, var.
+- Use arrows for causality: "inline obj -> new ref -> re-render -> wrap useMemo".
+- Preserve code, URLs, commands, paths, and file contents exactly. Never abbreviate inside code blocks.`
+	default:
+		return ""
+	}
+}
 
 type ProviderConfig struct {
 	AnthropicKey string

--- a/config/setup.go
+++ b/config/setup.go
@@ -46,14 +46,20 @@ func RunSetup(configDir string) error {
 		return fmt.Errorf("failed to init config: %w", err)
 	}
 
+	// Show hint only on re-run (when some values already exist)
+	if cfg.DiscordBotToken != "" || cfg.AnthropicAPIKey != "" || cfg.OpenAIAPIKey != "" {
+		fmt.Println("Press Enter to keep current value, - to clear.")
+		fmt.Println()
+	}
+
 	// Discord
 	fmt.Println("Discord")
 	cfg.DiscordBotToken = prompt("Bot token", cfg.DiscordBotToken)
-	cfg.DiscordOwnerID = prompt("Owner ID", cfg.DiscordOwnerID)
+	cfg.DiscordOwnerID = prompt("Your Discord user ID", cfg.DiscordOwnerID)
 
 	// LLM providers
 	fmt.Println()
-	fmt.Println("LLM providers (Enter to skip, - to clear)")
+	fmt.Println("LLM providers")
 	cfg.AnthropicAPIKey = prompt("Anthropic API key", cfg.AnthropicAPIKey)
 	cfg.OpenAIAPIKey = prompt("OpenAI API key", cfg.OpenAIAPIKey)
 	cfg.OllamaModel = prompt("Ollama model (e.g. llama3)", cfg.OllamaModel)

--- a/config/setup.go
+++ b/config/setup.go
@@ -71,10 +71,11 @@ func RunSetup(configDir string) error {
 
 	// Voice messages
 	fmt.Println()
+	fmt.Println("Voice messages")
 	whisperDir := filepath.Join(configDir, "whisper")
 	if voice.IsAvailable(whisperDir) {
-		fmt.Println("Voice messages: enabled")
-	} else if confirm("Enable voice messages?") {
+		fmt.Println("  Enabled.")
+	} else if confirm("  Enable voice messages?") {
 		if err := voice.Setup(whisperDir); err != nil {
 			fmt.Printf("Voice setup failed: %v\n", err)
 			fmt.Println("You can retry later with 'nevinho setup'.")


### PR DESCRIPTION
## What

Refactors response style guidelines from static agent configuration into a configurable system with multiple intensity levels (lite, full, ultra). Removes generic Discord-specific instructions from the core agent prompt and moves them to optional caveman modes. Improves setup UX with clearer field labels and contextual hints when re-running configuration.

## Changes
- Added `CAVEMAN` config field supporting `off`, `lite`, `full`, and `ultra` modes to control response compression levels                                                                 - Moved detailed response style guidelines (fragments, abbreviations, pattern-based wording) out of hardcoded agent.go into configurable `CavemanPrompt()` method
- Simplified default agent prompt to focus on Discord/phone readability; style now optional based on user preference
- Added validation in config.Set() to restrict CAVEMAN to valid values
- Consolidated setup prompt copy: added re-run hint showing Enter/dash behavior, improved field labels ("Your Discord user ID", "Voice messages" section), fixed indentation for consistency
- Removed generic instruction text about LLM provider skipping; users now see only the prompt itself