### PR TITLE
feat(web): improve search/fetch with retries and Tavily

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,5 @@ ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
 OLLAMA_MODEL=
 
-# Web search (optional — get a free key at https://brave.com/search/api/)
-BRAVE_API_KEY=
+# Web search (optional, get a free key at https://tavily.com — falls back to DuckDuckGo scraping if unset)
+TAVILY_API_KEY=

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -294,7 +294,7 @@ nevinho/
     registry.go        Tool dispatch, approval flow, path permissions
     bash.go            Shell execution, danger detection
     file.go            File read/write with sandboxing
-    web.go             Web search (Brave/DDG) and page fetch
+    web.go             Web search (Tavily/DDG) and page fetch
   discord/
     bot.go             Discord session, message handling, slash commands
   config/

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ whisper/            local Whisper model and binary (if voice enabled)
 
 You can also use a `.env` file in the project directory for development. Env vars take priority over encrypted config.
 
+Set `CAVEMAN` to `lite`, `full`, or `ultra` via `/config` for a token-saving response style. Off by default.
+
 ## Project structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Switch models at runtime with `/model` (dropdown selector) or `/model <name>`.
 | `bash` | Run any bash command |
 | `grep` | Search file contents by pattern |
 | `find` | Find files by name |
-| `web_search` | Search via Brave API or DuckDuckGo fallback |
+| `web_search` | Search via Tavily API or DuckDuckGo fallback |
 | `web_read` | Fetch a URL and extract readable text |
 | `file_list` | List directory contents |
 | `file_read` | Read a file (supports pagination) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,19 +33,38 @@ A single transient error or stuck call should not kill a conversation.
 
 - [x] **Voice transcription** -- Discord voice messages are downloaded and sent to OpenAI Whisper API. The transcribed text is fed to the agent as a normal message. Supports ogg, mp3, wav, m4a, webm formats. Requires `OPENAI_API_KEY`.
 
-## P4: Streaming
+## P4: Web Tooling
+
+Accurate, citeable answers depend on search and fetch quality. Current implementation is minimal hand-rolled HTML parsing that breaks on JS-rendered sites.
+
+**Minimal (reliability baseline):**
+
+- [ ] **Tavily deep search** -- Set `search_depth: "advanced"` and `include_answer: true` on Tavily calls. Surface the answer + citations instead of raw results.
+- [ ] **Tavily extract for webRead** -- When `TAVILY_API_KEY` is set, use `https://api.tavily.com/extract`. Handles JS-rendered pages, returns markdown.
+- [ ] **Readability fallback for no-key path** -- Use `go-shiori/go-readability` or proxy through Jina Reader (`r.jina.ai/<url>`) so webRead works on modern docs sites without a key.
+- [ ] **User-Agent + polite headers** -- Add `User-Agent: Nevinho/<version>` and `Accept: text/html,application/xhtml+xml` to outbound fetches. Avoids random 403s from Cloudflare-fronted sites.
+- [ ] **Clear error signaling to the model** -- Return explicit messages like "no results", "HTTP 403 forbidden", "timed out" so the model can decide to reformulate or retry instead of treating them as empty content.
+- [ ] **Retry on 429/5xx for web calls** -- Match the LLM retry layer: up to 3 attempts with backoff, parse `Retry-After`. Prevents transient blips from killing a search mid-conversation.
+
+**Polish (nice to have, ship when the pain shows up):**
+
+- [ ] **URL cache** -- In-memory LRU, 5 min TTL, keyed on URL. Agent re-reading the same page in one session pays once.
+- [ ] **PDF support** -- Detect `application/pdf`, extract text via `pdfcpu` or `ledongthuc/pdf`. Many specs live as PDFs.
+- [ ] **Search result dedup** -- Hash URLs/hostnames before returning. Avoid 3 copies of the same Stack Overflow answer.
+
+## P5: Streaming
 
 Waiting 20-40s with only a typing indicator provides no feedback. Streaming fixes this.
 
 - [ ] **Streaming responses** -- Use the streaming API endpoint. Edit the Discord message as tokens arrive instead of waiting for the full response.
 
-## P4: Persist Across Restarts
+## P6: Persist Across Restarts
 
 Conversations should survive process restarts and upgrades.
 
 - [ ] **Conversation summaries to disk** -- On trim or shutdown, write a summary to `~/.nevinho/summaries/{userID}.md`. On next message from that user, load the summary as context preamble.
 
-## P5: Scheduled Tasks
+## P7: Scheduled Tasks
 
 Nevinho runs 24/7 on a VPS. It should be able to run prompts on a schedule and report back to Discord.
 
@@ -59,7 +78,7 @@ Nevinho runs 24/7 on a VPS. It should be able to run prompts on a schedule and r
 
 Limits: max 10 active schedules, minimum interval 5 minutes, 5-minute execution timeout per run.
 
-## P6: Richer Interactions
+## P8: Richer Interactions
 
 Only after the foundation is solid.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,12 +39,12 @@ Accurate, citeable answers depend on search and fetch quality. Current implement
 
 **Minimal (reliability baseline):**
 
-- [ ] **Tavily deep search** -- Set `search_depth: "advanced"` and `include_answer: true` on Tavily calls. Surface the answer + citations instead of raw results.
-- [ ] **Tavily extract for webRead** -- When `TAVILY_API_KEY` is set, use `https://api.tavily.com/extract`. Handles JS-rendered pages, returns markdown.
-- [ ] **Readability fallback for no-key path** -- Use `go-shiori/go-readability` or proxy through Jina Reader (`r.jina.ai/<url>`) so webRead works on modern docs sites without a key.
-- [ ] **User-Agent + polite headers** -- Add `User-Agent: Nevinho/<version>` and `Accept: text/html,application/xhtml+xml` to outbound fetches. Avoids random 403s from Cloudflare-fronted sites.
-- [ ] **Clear error signaling to the model** -- Return explicit messages like "no results", "HTTP 403 forbidden", "timed out" so the model can decide to reformulate or retry instead of treating them as empty content.
-- [ ] **Retry on 429/5xx for web calls** -- Match the LLM retry layer: up to 3 attempts with backoff, parse `Retry-After`. Prevents transient blips from killing a search mid-conversation.
+- [x] **Tavily deep search** -- Set `search_depth: "advanced"` and `include_answer: true` on Tavily calls. Surface the answer + citations instead of raw results.
+- [x] **Tavily extract for webRead** -- When `TAVILY_API_KEY` is set, use `https://api.tavily.com/extract`. Handles JS-rendered pages, returns markdown.
+- [x] **Jina Reader fallback for no-key path** -- Proxy through Jina Reader (`r.jina.ai/<url>`) so webRead works on modern JS-rendered docs sites without a key. Free tier is 20 RPM anonymous.
+- [x] **User-Agent + polite headers** -- `User-Agent: Nevinho/<version>`, `Accept`, and `Accept-Language` on outbound fetches. Avoids random 403s from Cloudflare-fronted sites.
+- [x] **Clear error signaling to the model** -- Explicit messages like "HTTP 403 forbidden (try another source)", "HTTP 429 rate limited (back off)", "timed out", "DNS lookup failed" so the model can decide to reformulate or retry instead of treating them as empty content.
+- [x] **Retry on 429/5xx for web calls** -- Matches the LLM retry layer: up to 3 attempts with exponential backoff, parses `Retry-After`. Prevents transient blips from killing a search mid-conversation.
 
 **Polish (nice to have, ship when the pain shows up):**
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -43,9 +43,11 @@ You need at least one LLM provider. You can configure multiple and switch betwee
 1. Install from https://ollama.com
 2. Pull a model: `ollama pull llama3`
 
-**Brave Search (optional, for web search):**
-1. Go to https://brave.com/search/api
-2. Get a free API key (2000 queries/month)
+**Tavily Search (optional, for web search):**
+1. Go to https://tavily.com
+2. Sign up and get a free API key (1000 queries/month, no credit card required)
+
+Without a key, nevinho falls back to DuckDuckGo HTML scraping.
 
 ## 5. Configure the project
 
@@ -66,7 +68,7 @@ OPENAI_API_KEY=paste_your_openai_key
 OLLAMA_MODEL=llama3
 
 # Optional
-BRAVE_API_KEY=paste_your_brave_key
+TAVILY_API_KEY=paste_your_tavily_key
 ```
 
 ## 6. Run it locally

--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	AnthropicAPIKey string `json:"anthropic_api_key"`
 	OpenAIAPIKey    string `json:"openai_api_key"`
 	OllamaModel     string `json:"ollama_model"`
-	BraveAPIKey     string `json:"brave_api_key"`
+	TavilyAPIKey    string `json:"tavily_api_key"`
 	Model           string `json:"model"`
 	Caveman         string `json:"caveman"`
 }
@@ -34,7 +34,7 @@ func (c *Config) keymap() map[string]*string {
 		"ANTHROPIC_API_KEY": &c.AnthropicAPIKey,
 		"OPENAI_API_KEY":    &c.OpenAIAPIKey,
 		"OLLAMA_MODEL":      &c.OllamaModel,
-		"BRAVE_API_KEY":     &c.BraveAPIKey,
+		"TAVILY_API_KEY":    &c.TavilyAPIKey,
 		"MODEL":             &c.Model,
 		"CAVEMAN":           &c.Caveman,
 	}
@@ -137,7 +137,7 @@ func (c *Config) Keys() []KeyStatus {
 	order := []string{
 		"DISCORD_BOT_TOKEN", "DISCORD_OWNER_ID",
 		"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OLLAMA_MODEL",
-		"BRAVE_API_KEY", "MODEL", "CAVEMAN",
+		"TAVILY_API_KEY", "MODEL", "CAVEMAN",
 	}
 
 	km := c.keymap()

--- a/config/setup.go
+++ b/config/setup.go
@@ -73,7 +73,7 @@ func RunSetup(configDir string) error {
 	// Optional
 	fmt.Println()
 	fmt.Println("Optional")
-	cfg.BraveAPIKey = prompt("Brave Search API key", cfg.BraveAPIKey)
+	cfg.TavilyAPIKey = prompt("Tavily Search API key", cfg.TavilyAPIKey)
 
 	// Voice messages
 	fmt.Println()
@@ -99,7 +99,7 @@ func RunSetup(configDir string) error {
 	printStatus("  Anthropic", cfg.AnthropicAPIKey != "")
 	printStatus("  OpenAI", cfg.OpenAIAPIKey != "")
 	printStatus("  Ollama", cfg.OllamaModel != "")
-	printStatus("  Brave Search", cfg.BraveAPIKey != "")
+	printStatus("  Tavily Search", cfg.TavilyAPIKey != "")
 	printStatus("  Voice", voice.IsAvailable(whisperDir))
 
 	fmt.Println()

--- a/discord/bot.go
+++ b/discord/bot.go
@@ -585,7 +585,7 @@ func (b *Bot) configStatus() string {
 
 func isSecretKey(key string) bool {
 	switch key {
-	case "DISCORD_BOT_TOKEN", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "BRAVE_API_KEY":
+	case "DISCORD_BOT_TOKEN", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "TAVILY_API_KEY":
 		return true
 	}
 	return false

--- a/discord/bot.go
+++ b/discord/bot.go
@@ -567,15 +567,28 @@ func (b *Bot) configStatus() string {
 	var sb strings.Builder
 	sb.WriteString("**Configuration**\n")
 	for _, k := range keys {
-		if k.Set {
-			fmt.Fprintf(&sb, "• `%s`: set (%s)\n", k.Name, k.Source)
-		} else {
+		if !k.Set {
 			fmt.Fprintf(&sb, "• `%s`: not set\n", k.Name)
+			continue
 		}
+		if isSecretKey(k.Name) {
+			fmt.Fprintf(&sb, "• `%s`: set (%s)\n", k.Name, k.Source)
+			continue
+		}
+		val, _ := b.cfg.Get(k.Name)
+		fmt.Fprintf(&sb, "• `%s`: %s (%s)\n", k.Name, val, k.Source)
 	}
 	sb.WriteString("\nUpdate: `/config key:KEY value:VALUE`")
 	sb.WriteString("\nClear: `/config key:KEY`")
 	return sb.String()
+}
+
+func isSecretKey(key string) bool {
+	switch key {
+	case "DISCORD_BOT_TOKEN", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "BRAVE_API_KEY":
+		return true
+	}
+	return false
 }
 
 func (b *Bot) configSet(key, value string) string {

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -90,12 +90,12 @@ When you use information from a fetched page in your answer, cite the source URL
 		},
 		{
 			Name: "web_search",
-			Description: `Search the web and return titles, URLs, and snippets for the top results.
-Use this to find relevant pages, then use web_read to get full content.
+			Description: `Search the web. Returns a summarized answer (when available) followed by source titles, URLs, and snippets.
+Use this to find relevant pages, then use web_read to get full content if the snippets are not enough.
 When to use:
 - Any knowledge question where an authoritative source exists (official docs, specs, project homepage, standards, reference manuals). This includes "what is X", "how does X work", "how do I do X", "why does X happen", comparisons, and best practices. The user wants references they can share with colleagues, so do not answer from memory alone when a citeable source is available.
 - Anything time-sensitive: versions, releases, news, pricing, current status.
-When you use information from search results or pages you read, cite each source URL at the end of your answer on its own line: "Source: <url>". Multiple sources get multiple lines.`,
+When you use information from the answer or sources, cite each source URL at the end of your reply on its own line: "Source: <url>". Multiple sources get multiple lines.`,
 			Schema: `{"type":"object","properties":{"query":{"type":"string","description":"Search query"}},"required":["query"]}`,
 		},
 		{

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -92,6 +92,9 @@ When you use information from a fetched page in your answer, cite the source URL
 			Name: "web_search",
 			Description: `Search the web and return titles, URLs, and snippets for the top results.
 Use this to find relevant pages, then use web_read to get full content.
+When to use:
+- Any knowledge question where an authoritative source exists (official docs, specs, project homepage, standards, reference manuals). This includes "what is X", "how does X work", "how do I do X", "why does X happen", comparisons, and best practices. The user wants references they can share with colleagues, so do not answer from memory alone when a citeable source is available.
+- Anything time-sensitive: versions, releases, news, pricing, current status.
 When you use information from search results or pages you read, cite each source URL at the end of your answer on its own line: "Source: <url>". Multiple sources get multiple lines.`,
 			Schema: `{"type":"object","properties":{"query":{"type":"string","description":"Search query"}},"required":["query"]}`,
 		},

--- a/tools/web.go
+++ b/tools/web.go
@@ -75,22 +75,29 @@ func (r *Registry) webSearch(input json.RawMessage) string {
 		return fmt.Sprintf("invalid input: %v", err)
 	}
 
-	if r.cfg.BraveAPIKey != "" {
-		return searchBrave(in.Query, r.cfg.BraveAPIKey)
+	if r.cfg.TavilyAPIKey != "" {
+		return searchTavily(in.Query, r.cfg.TavilyAPIKey)
 	}
 	return searchDuckDuckGo(in.Query)
 }
 
-func searchBrave(query, apiKey string) string {
+func searchTavily(query, apiKey string) string {
 	client := &http.Client{Timeout: httpTimeout}
-	reqURL := fmt.Sprintf("https://api.search.brave.com/res/v1/web/search?q=%s&count=5", url.QueryEscape(query))
 
-	req, err := http.NewRequest("GET", reqURL, nil)
+	reqBody, err := json.Marshal(map[string]any{
+		"api_key":     apiKey,
+		"query":       query,
+		"max_results": 5,
+	})
+	if err != nil {
+		return fmt.Sprintf("failed to build request: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", "https://api.tavily.com/search", strings.NewReader(string(reqBody)))
 	if err != nil {
 		return fmt.Sprintf("failed to create request: %v", err)
 	}
-	req.Header.Set("X-Subscription-Token", apiKey)
-	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -103,21 +110,34 @@ func searchBrave(query, apiKey string) string {
 		return fmt.Sprintf("failed to read search response: %v", err)
 	}
 
+	if resp.StatusCode != 200 {
+		return fmt.Sprintf("search failed: HTTP %d", resp.StatusCode)
+	}
+
 	var result struct {
-		Web struct {
-			Results []struct {
-				Title       string `json:"title"`
-				URL         string `json:"url"`
-				Description string `json:"description"`
-			} `json:"results"`
-		} `json:"web"`
+		Answer  string `json:"answer"`
+		Results []struct {
+			Title   string `json:"title"`
+			URL     string `json:"url"`
+			Content string `json:"content"`
+		} `json:"results"`
 	}
 
 	if err := json.Unmarshal(body, &result); err != nil {
 		return fmt.Sprintf("failed to parse results: %v", err)
 	}
 
-	return formatSearchResults(result.Web.Results)
+	out := make([]struct {
+		Title       string `json:"title"`
+		URL         string `json:"url"`
+		Description string `json:"description"`
+	}, len(result.Results))
+	for i, r := range result.Results {
+		out[i].Title = r.Title
+		out[i].URL = r.URL
+		out[i].Description = r.Content
+	}
+	return formatSearchResults(out)
 }
 
 func searchDuckDuckGo(query string) string {

--- a/tools/web.go
+++ b/tools/web.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -15,6 +16,103 @@ import (
 )
 
 const httpTimeout = 15 * time.Second
+
+const userAgent = "Nevinho/1.0 (+https://github.com/lucasnevespereira/nevinho)"
+
+// fetchWithRetry performs an HTTP request with up to 3 attempts, retrying on
+// 429/5xx and transient transport errors. Respects Retry-After on 429.
+// Returns the response body (capped at maxBody), status code, and any error.
+func fetchWithRetry(client *http.Client, makeReq func() (*http.Request, error), maxBody int64) ([]byte, int, error) {
+	const attempts = 3
+	var lastErr error
+	for attempt := range attempts {
+		req, err := makeReq()
+		if err != nil {
+			return nil, 0, err
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			if attempt < attempts-1 {
+				time.Sleep(backoffWeb(attempt))
+				continue
+			}
+			return nil, 0, err
+		}
+
+		body, rerr := io.ReadAll(io.LimitReader(resp.Body, maxBody))
+		resp.Body.Close()
+		if rerr != nil {
+			return nil, resp.StatusCode, rerr
+		}
+
+		if !isRetryableStatus(resp.StatusCode) {
+			return body, resp.StatusCode, nil
+		}
+
+		if attempt == attempts-1 {
+			return body, resp.StatusCode, nil
+		}
+
+		delay := backoffWeb(attempt)
+		if resp.StatusCode == 429 {
+			if ra := resp.Header.Get("Retry-After"); ra != "" {
+				if secs, perr := strconv.Atoi(ra); perr == nil && secs > 0 && secs <= 60 {
+					delay = time.Duration(secs) * time.Second
+				}
+			}
+		}
+		time.Sleep(delay)
+	}
+	return nil, 0, lastErr
+}
+
+func isRetryableStatus(code int) bool {
+	return code == 429 || code >= 500
+}
+
+func backoffWeb(attempt int) time.Duration {
+	return time.Duration(1<<attempt) * time.Second
+}
+
+// describeFetchErr converts a transport error into a short actionable label.
+// The model uses this to decide whether to retry, reformulate, or abandon.
+func describeFetchErr(err error) string {
+	s := err.Error()
+	switch {
+	case strings.Contains(s, "context deadline exceeded"), strings.Contains(s, "Client.Timeout"):
+		return "timed out"
+	case strings.Contains(s, "no such host"):
+		return "DNS lookup failed (host does not exist)"
+	case strings.Contains(s, "connection refused"):
+		return "connection refused"
+	case strings.Contains(s, "connection reset"):
+		return "connection reset"
+	case strings.Contains(s, "TLS"), strings.Contains(s, "certificate"):
+		return "TLS/certificate error"
+	}
+	return s
+}
+
+// describeHTTPStatus returns a short hint about what an HTTP status means for the agent.
+func describeHTTPStatus(code int) string {
+	switch code {
+	case 401:
+		return "HTTP 401 unauthorized (auth required)"
+	case 403:
+		return "HTTP 403 forbidden (site blocked the request, try another source)"
+	case 404:
+		return "HTTP 404 not found (URL is wrong or page was removed)"
+	case 408:
+		return "HTTP 408 request timeout"
+	case 429:
+		return "HTTP 429 rate limited (back off before retrying)"
+	case 500, 502, 503, 504:
+		return fmt.Sprintf("HTTP %d server error (transient, safe to retry)", code)
+	}
+	return fmt.Sprintf("HTTP %d", code)
+}
 
 type webReadInput struct {
 	URL string `json:"url"`
@@ -30,6 +128,46 @@ func (r *Registry) webRead(input json.RawMessage) string {
 		return fmt.Sprintf("blocked: %v", err)
 	}
 
+	if r.cfg.TavilyAPIKey != "" {
+		if out := extractTavily(in.URL, r.cfg.TavilyAPIKey); !isFetchFailure(out) {
+			return truncateText(out)
+		}
+	}
+
+	if out := fetchJinaReader(in.URL); !isFetchFailure(out) {
+		return truncateText(out)
+	}
+
+	return fetchDirect(in.URL)
+}
+
+func fetchJinaReader(target string) string {
+	client := &http.Client{Timeout: httpTimeout}
+
+	body, status, err := fetchWithRetry(client, func() (*http.Request, error) {
+		req, err := http.NewRequest("GET", "https://r.jina.ai/"+target, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("User-Agent", userAgent)
+		req.Header.Set("Accept", "text/plain")
+		return req, nil
+	}, 1024*1024)
+	if err != nil {
+		return fmt.Sprintf("failed to fetch: %s", describeFetchErr(err))
+	}
+	if status != 200 {
+		return describeHTTPStatus(status)
+	}
+
+	out := strings.TrimSpace(string(body))
+	if out == "" {
+		return "no content extracted"
+	}
+	return out
+}
+
+func fetchDirect(target string) string {
 	client := &http.Client{
 		Timeout: httpTimeout,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
@@ -42,27 +180,98 @@ func (r *Registry) webRead(input json.RawMessage) string {
 			return nil
 		},
 	}
-	resp, err := client.Get(in.URL)
+
+	body, status, err := fetchWithRetry(client, func() (*http.Request, error) {
+		req, err := http.NewRequest("GET", target, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("User-Agent", userAgent)
+		req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+		req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+		return req, nil
+	}, 500*1024)
 	if err != nil {
-		return fmt.Sprintf("failed to fetch: %v", err)
+		return fmt.Sprintf("failed to fetch: %s", describeFetchErr(err))
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return fmt.Sprintf("HTTP %d", resp.StatusCode)
+	if status != 200 {
+		return describeHTTPStatus(status)
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 500*1024))
+	return truncateText(extractText(string(body)))
+}
+
+func extractTavily(target, apiKey string) string {
+	client := &http.Client{Timeout: httpTimeout}
+
+	reqBody, err := json.Marshal(map[string]any{
+		"api_key":        apiKey,
+		"urls":           []string{target},
+		"extract_depth":  "basic",
+		"include_images": false,
+	})
 	if err != nil {
-		return fmt.Sprintf("failed to read body: %v", err)
+		return fmt.Sprintf("failed to build request: %v", err)
 	}
 
-	text := extractText(string(body))
-	if len(text) > maxResponseLen {
-		text = text[:maxResponseLen] + "\n...(truncated)"
+	body, status, err := fetchWithRetry(client, func() (*http.Request, error) {
+		req, err := http.NewRequest("POST", "https://api.tavily.com/extract", strings.NewReader(string(reqBody)))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	}, 1024*1024)
+	if err != nil {
+		return fmt.Sprintf("failed to fetch: %s", describeFetchErr(err))
+	}
+	if status != 200 {
+		return describeHTTPStatus(status)
 	}
 
-	return text
+	var result struct {
+		Results []struct {
+			URL        string `json:"url"`
+			RawContent string `json:"raw_content"`
+		} `json:"results"`
+		FailedResults []struct {
+			URL   string `json:"url"`
+			Error string `json:"error"`
+		} `json:"failed_results"`
+	}
+
+	if err := json.Unmarshal(body, &result); err != nil {
+		return fmt.Sprintf("failed to parse response: %v", err)
+	}
+
+	if len(result.Results) == 0 {
+		if len(result.FailedResults) > 0 {
+			return fmt.Sprintf("failed to fetch: %s", result.FailedResults[0].Error)
+		}
+		return "no content extracted"
+	}
+
+	return result.Results[0].RawContent
+}
+
+// isFetchFailure returns true when a fetch provider returned an error,
+// so the caller can fall through to the next provider.
+func isFetchFailure(out string) bool {
+	if out == "" {
+		return true
+	}
+	lower := strings.ToLower(out)
+	return strings.HasPrefix(lower, "failed to") ||
+		strings.HasPrefix(lower, "http ") ||
+		strings.HasPrefix(lower, "no content") ||
+		strings.HasPrefix(lower, "blocked:")
+}
+
+func truncateText(s string) string {
+	if len(s) > maxResponseLen {
+		return s[:maxResponseLen] + "\n...(truncated)"
+	}
+	return s
 }
 
 type webSearchInput struct {
@@ -76,42 +285,52 @@ func (r *Registry) webSearch(input json.RawMessage) string {
 	}
 
 	if r.cfg.TavilyAPIKey != "" {
-		return searchTavily(in.Query, r.cfg.TavilyAPIKey)
+		if out := searchTavily(in.Query, r.cfg.TavilyAPIKey); !isSearchFailure(out) {
+			return out
+		}
 	}
 	return searchDuckDuckGo(in.Query)
+}
+
+// isSearchFailure returns true when a provider returned an error or empty result,
+// so the caller can fall through to the next provider.
+func isSearchFailure(out string) bool {
+	if out == "" {
+		return true
+	}
+	lower := strings.ToLower(out)
+	return strings.HasPrefix(lower, "search failed") ||
+		strings.HasPrefix(lower, "no results") ||
+		strings.HasPrefix(lower, "failed to")
 }
 
 func searchTavily(query, apiKey string) string {
 	client := &http.Client{Timeout: httpTimeout}
 
 	reqBody, err := json.Marshal(map[string]any{
-		"api_key":     apiKey,
-		"query":       query,
-		"max_results": 5,
+		"api_key":        apiKey,
+		"query":          query,
+		"max_results":    5,
+		"search_depth":   "advanced",
+		"include_answer": true,
 	})
 	if err != nil {
 		return fmt.Sprintf("failed to build request: %v", err)
 	}
 
-	req, err := http.NewRequest("POST", "https://api.tavily.com/search", strings.NewReader(string(reqBody)))
+	body, status, err := fetchWithRetry(client, func() (*http.Request, error) {
+		req, err := http.NewRequest("POST", "https://api.tavily.com/search", strings.NewReader(string(reqBody)))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	}, 1024*1024)
 	if err != nil {
-		return fmt.Sprintf("failed to create request: %v", err)
+		return fmt.Sprintf("search failed: %s", describeFetchErr(err))
 	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return fmt.Sprintf("search failed: %v", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Sprintf("failed to read search response: %v", err)
-	}
-
-	if resp.StatusCode != 200 {
-		return fmt.Sprintf("search failed: HTTP %d", resp.StatusCode)
+	if status != 200 {
+		return fmt.Sprintf("search failed: %s", describeHTTPStatus(status))
 	}
 
 	var result struct {
@@ -127,38 +346,40 @@ func searchTavily(query, apiKey string) string {
 		return fmt.Sprintf("failed to parse results: %v", err)
 	}
 
-	out := make([]struct {
-		Title       string `json:"title"`
-		URL         string `json:"url"`
-		Description string `json:"description"`
-	}, len(result.Results))
-	for i, r := range result.Results {
-		out[i].Title = r.Title
-		out[i].URL = r.URL
-		out[i].Description = r.Content
+	if len(result.Results) == 0 && result.Answer == "" {
+		return "no results found"
 	}
-	return formatSearchResults(out)
+
+	var sb strings.Builder
+	if result.Answer != "" {
+		sb.WriteString("**Answer:** ")
+		sb.WriteString(result.Answer)
+		sb.WriteString("\n\n")
+	}
+	sb.WriteString("**Sources:**\n")
+	for i, r := range result.Results {
+		fmt.Fprintf(&sb, "%d. **%s**\n   %s\n   %s\n\n", i+1, r.Title, r.URL, r.Content)
+	}
+	return sb.String()
 }
 
 func searchDuckDuckGo(query string) string {
 	client := &http.Client{Timeout: httpTimeout}
 	reqURL := fmt.Sprintf("https://html.duckduckgo.com/html/?q=%s", url.QueryEscape(query))
 
-	req, err := http.NewRequest("GET", reqURL, nil)
+	body, status, err := fetchWithRetry(client, func() (*http.Request, error) {
+		req, err := http.NewRequest("GET", reqURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("User-Agent", userAgent)
+		return req, nil
+	}, 500*1024)
 	if err != nil {
-		return fmt.Sprintf("failed to create request: %v", err)
+		return fmt.Sprintf("search failed: %s", describeFetchErr(err))
 	}
-	req.Header.Set("User-Agent", "Nevinho/1.0")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return fmt.Sprintf("search failed: %v", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 500*1024))
-	if err != nil {
-		return fmt.Sprintf("failed to read response: %v", err)
+	if status != 200 {
+		return fmt.Sprintf("search failed: %s", describeHTTPStatus(status))
 	}
 
 	return parseDuckDuckGoHTML(string(body))
@@ -209,21 +430,6 @@ func parseDuckDuckGoHTML(htmlContent string) string {
 		results = results[:5]
 	}
 
-	var sb strings.Builder
-	for i, r := range results {
-		fmt.Fprintf(&sb, "%d. **%s**\n   %s\n   %s\n\n", i+1, r.Title, r.URL, r.Description)
-	}
-	return sb.String()
-}
-
-func formatSearchResults(results []struct {
-	Title       string `json:"title"`
-	URL         string `json:"url"`
-	Description string `json:"description"`
-}) string {
-	if len(results) == 0 {
-		return "no results found"
-	}
 	var sb strings.Builder
 	for i, r := range results {
 		fmt.Fprintf(&sb, "%d. **%s**\n   %s\n   %s\n\n", i+1, r.Title, r.URL, r.Description)


### PR DESCRIPTION
## What
Improved web search and fetch reliability with automatic retries, intelligent fallbacks, and clearer error signaling. Switched from Brave Search to Tavily API for better accuracy and citeable answers. Enhanced config display to show non-secret settings while protecting API keys.

## Changes
- Implemented retry logic with exponential backoff (up to 3 attempts) for web calls; respects `Retry-After` header on 429 responses
- Added fetch provider chain: Tavily extract → Jina Reader → direct fetch, falling through on failure- Switched web search from Brave API to Tavily with `search_depth: "advanced"` and `include_answer` for better results
- Descriptive HTTP error messages for the model ("HTTP 403 forbidden (try another source)", "timed out", "DNS lookup failed")
- Added User-Agent, Accept, and Accept-Language headers to reduce 403s from Cloudflare-fronted sites
- Updated `/config` to display values for OLLAMA_MODEL, MODEL, and CAVEMAN settings while hiding secrets (API keys, tokens)
- Updated ROADMAP: consolidated web tooling tasks as "P4: Web Tooling" (completed), renumbered streaming/persistence/scheduling sections
- Updated SETUP.md and .env.example to reference Tavily with DuckDuckGo fallback note
- Updated tool description to clarify when web_search should be used (knowledge questions, time-sensitive info)