### PR TITLE
feat: tool activity indicator

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -47,6 +47,17 @@ Guidelines:
 - The user reads on Discord, often on a phone. Keep answers compact. Avoid wide tables and long horizontal lines.`
 )
 
+// ToolEvent fires when the agent begins executing a tool call. Consumers
+// (Discord bot, CLI) use it to render a live activity indicator so the user
+// sees what the agent is doing instead of staring at a typing indicator.
+type ToolEvent struct {
+	Name   string
+	Detail string
+}
+
+// ToolCallback receives ToolEvent values for a specific user.
+type ToolCallback func(ToolEvent)
+
 type Agent struct {
 	llm     llm.Provider
 	tools   *tools.Registry
@@ -57,6 +68,7 @@ type Agent struct {
 	history   map[string][]json.RawMessage
 	userLock  map[string]*sync.Mutex
 	cancelFn  map[string]context.CancelFunc
+	toolCb    map[string]ToolCallback
 	startTime time.Time
 	tokensIn  int
 	tokensOut int
@@ -71,8 +83,35 @@ func New(provider llm.Provider, cfg *config.Config, version string) *Agent {
 		history:   make(map[string][]json.RawMessage),
 		userLock:  make(map[string]*sync.Mutex),
 		cancelFn:  make(map[string]context.CancelFunc),
+		toolCb:    make(map[string]ToolCallback),
 		startTime: time.Now(),
 	}
+}
+
+// SetToolCallback registers a per-user callback fired when a tool call starts.
+// Pass nil to clear. Callers should set before Chat and clear in a defer.
+func (a *Agent) SetToolCallback(userID string, cb ToolCallback) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if cb == nil {
+		delete(a.toolCb, userID)
+		return
+	}
+	a.toolCb[userID] = cb
+}
+
+func (a *Agent) emitToolEvent(userID, name, detail string) {
+	a.mu.Lock()
+	cb := a.toolCb[userID]
+	a.mu.Unlock()
+	if cb == nil {
+		return
+	}
+	defer func() {
+		// Never let a buggy consumer callback take down the agent loop.
+		_ = recover()
+	}()
+	cb(ToolEvent{Name: name, Detail: detail})
 }
 
 func (a *Agent) Cancel(userID string) bool {
@@ -186,7 +225,9 @@ func (a *Agent) Chat(userID, text string, isVoice bool) (string, error) {
 		needsApproval := false
 		for _, tc := range resp.ToolCalls {
 			toolsUsed = append(toolsUsed, tc.Name)
-			logger.Tool(tc.Name, toolDetail(tc.Name, tc.Input))
+			detail := toolDetail(tc.Name, tc.Input)
+			logger.Tool(tc.Name, detail)
+			a.emitToolEvent(userID, tc.Name, detail)
 			output := a.executeTool(ctx, tc.Name, tc.Input, userID)
 			if len(output) > maxToolResult {
 				output = output[:maxToolResult] + "\n...(truncated)"

--- a/discord/bot.go
+++ b/discord/bot.go
@@ -349,7 +349,12 @@ func (b *Bot) onMessage(s *discordgo.Session, m *discordgo.MessageCreate) {
 	s.ChannelTyping(m.ChannelID)
 	stopTyping := keepTyping(s, m.ChannelID)
 
+	indicator := newActivityIndicator(s, m.ChannelID)
+	b.agent.SetToolCallback(m.Author.ID, indicator.onEvent)
+
 	response, err := b.agent.Chat(m.Author.ID, text, isVoice)
+	b.agent.SetToolCallback(m.Author.ID, nil)
+	indicator.Close()
 	stopTyping()
 	if err != nil {
 		log.Printf("agent error for user %s: %v", m.Author.ID, err)
@@ -722,7 +727,12 @@ func (b *Bot) runApproval(s *discordgo.Session, channelID, userID string) {
 	s.ChannelTyping(channelID)
 	stopTyping := keepTyping(s, channelID)
 
+	indicator := newActivityIndicator(s, channelID)
+	b.agent.SetToolCallback(userID, indicator.onEvent)
+
 	response, err := b.agent.Chat(userID, "yes", false)
+	b.agent.SetToolCallback(userID, nil)
+	indicator.Close()
 	stopTyping()
 	if err != nil {
 		s.ChannelMessageSend(channelID, friendlyError(err))

--- a/discord/indicator.go
+++ b/discord/indicator.go
@@ -50,7 +50,11 @@ func (a *activityIndicator) onEvent(ev agent.ToolEvent) {
 	content := formatIndicator(ev.Name, ev.Detail)
 
 	if a.messageID == "" {
-		msg, err := a.session.ChannelMessageSend(a.channelID, content)
+		msg, err := a.session.ChannelMessageSendComplex(a.channelID, &discordgo.MessageSend{
+			Content: content,
+			// Keep the indicator silent on mobile. It is metadata, not a reply.
+			Flags: discordgo.MessageFlagsSuppressNotifications,
+		})
 		if err != nil {
 			return
 		}
@@ -85,13 +89,15 @@ func (a *activityIndicator) Close() {
 
 func formatIndicator(name, detail string) string {
 	detail = strings.TrimSpace(detail)
+	// -# renders as small, muted subtext in Discord so the indicator reads as
+	// metadata rather than a regular message.
 	if detail == "" {
-		return fmt.Sprintf("_running %s..._", name)
+		return fmt.Sprintf("-# running %s...", name)
 	}
 	if len(detail) > indicatorMaxDetail {
 		detail = detail[:indicatorMaxDetail] + "..."
 	}
-	return fmt.Sprintf("_running %s:_ `%s`", name, escapeBackticks(detail))
+	return fmt.Sprintf("-# running %s: `%s`", name, escapeBackticks(detail))
 }
 
 // escapeBackticks prevents a detail that contains backticks from breaking out

--- a/discord/indicator.go
+++ b/discord/indicator.go
@@ -1,0 +1,101 @@
+package discord
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/lucasnevespereira/nevinho/agent"
+)
+
+const (
+	indicatorMinInterval = 600 * time.Millisecond
+	indicatorMaxDetail   = 80
+)
+
+// activityIndicator maintains a single Discord message that reflects the
+// currently running tool call. It creates the message lazily on the first
+// event, edits it on subsequent events, and deletes it on Close.
+//
+// Discord rate-limits edits to roughly 5 per 5s per channel. We throttle to
+// one edit per ~600ms which keeps us well under that ceiling while staying
+// responsive for the user.
+type activityIndicator struct {
+	session   *discordgo.Session
+	channelID string
+
+	mu        sync.Mutex
+	messageID string
+	lastEdit  time.Time
+	closed    bool
+}
+
+func newActivityIndicator(s *discordgo.Session, channelID string) *activityIndicator {
+	return &activityIndicator{session: s, channelID: channelID}
+}
+
+// onEvent is the agent.ToolCallback. It runs on the agent's goroutine; all
+// Discord API calls happen inline so the agent sees back-pressure if Discord
+// is slow.
+func (a *activityIndicator) onEvent(ev agent.ToolEvent) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.closed {
+		return
+	}
+
+	content := formatIndicator(ev.Name, ev.Detail)
+
+	if a.messageID == "" {
+		msg, err := a.session.ChannelMessageSend(a.channelID, content)
+		if err != nil {
+			return
+		}
+		a.messageID = msg.ID
+		a.lastEdit = time.Now()
+		return
+	}
+
+	if time.Since(a.lastEdit) < indicatorMinInterval {
+		return
+	}
+	if _, err := a.session.ChannelMessageEdit(a.channelID, a.messageID, content); err == nil {
+		a.lastEdit = time.Now()
+	}
+}
+
+// Close deletes the indicator message if one was posted. Safe to call more
+// than once.
+func (a *activityIndicator) Close() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.closed {
+		return
+	}
+	a.closed = true
+	if a.messageID == "" {
+		return
+	}
+	a.session.ChannelMessageDelete(a.channelID, a.messageID)
+	a.messageID = ""
+}
+
+func formatIndicator(name, detail string) string {
+	detail = strings.TrimSpace(detail)
+	if detail == "" {
+		return fmt.Sprintf("_running %s..._", name)
+	}
+	if len(detail) > indicatorMaxDetail {
+		detail = detail[:indicatorMaxDetail] + "..."
+	}
+	return fmt.Sprintf("_running %s:_ `%s`", name, escapeBackticks(detail))
+}
+
+// escapeBackticks prevents a detail that contains backticks from breaking out
+// of the inline code span in the indicator message.
+func escapeBackticks(s string) string {
+	return strings.ReplaceAll(s, "`", "'")
+}

--- a/discord/indicator_test.go
+++ b/discord/indicator_test.go
@@ -1,0 +1,74 @@
+package discord
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatIndicator(t *testing.T) {
+	tests := []struct {
+		name    string
+		toolN   string
+		detail  string
+		want    string
+		include string
+	}{
+		{
+			name:   "no detail",
+			toolN:  "bash",
+			detail: "",
+			want:   "_running bash..._",
+		},
+		{
+			name:   "with detail wraps in code span",
+			toolN:  "bash",
+			detail: "ls -la",
+			want:   "_running bash:_ `ls -la`",
+		},
+		{
+			name:   "whitespace-only detail is treated as empty",
+			toolN:  "bash",
+			detail: "   ",
+			want:   "_running bash..._",
+		},
+		{
+			name:    "truncates long detail",
+			toolN:   "web_search",
+			detail:  strings.Repeat("x", 200),
+			include: "...`",
+		},
+		{
+			name:   "escapes backticks in detail",
+			toolN:  "bash",
+			detail: "echo `whoami`",
+			want:   "_running bash:_ `echo 'whoami'`",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatIndicator(tt.toolN, tt.detail)
+			if tt.want != "" && got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+			if tt.include != "" && !strings.Contains(got, tt.include) {
+				t.Errorf("got %q, want to contain %q", got, tt.include)
+			}
+		})
+	}
+}
+
+func TestFormatIndicator_RespectsMaxDetailLength(t *testing.T) {
+	detail := strings.Repeat("a", indicatorMaxDetail+50)
+	got := formatIndicator("bash", detail)
+	// Body between backticks must not exceed indicatorMaxDetail + 3 for "...".
+	openIdx := strings.Index(got, "`")
+	closeIdx := strings.LastIndex(got, "`")
+	if openIdx == -1 || closeIdx == -1 || openIdx == closeIdx {
+		t.Fatalf("expected backticks, got %q", got)
+	}
+	body := got[openIdx+1 : closeIdx]
+	if len(body) > indicatorMaxDetail+3 {
+		t.Errorf("body length %d exceeds max+3 (%d): %q", len(body), indicatorMaxDetail+3, body)
+	}
+}

--- a/discord/indicator_test.go
+++ b/discord/indicator_test.go
@@ -17,19 +17,19 @@ func TestFormatIndicator(t *testing.T) {
 			name:   "no detail",
 			toolN:  "bash",
 			detail: "",
-			want:   "_running bash..._",
+			want:   "-# running bash...",
 		},
 		{
 			name:   "with detail wraps in code span",
 			toolN:  "bash",
 			detail: "ls -la",
-			want:   "_running bash:_ `ls -la`",
+			want:   "-# running bash: `ls -la`",
 		},
 		{
 			name:   "whitespace-only detail is treated as empty",
 			toolN:  "bash",
 			detail: "   ",
-			want:   "_running bash..._",
+			want:   "-# running bash...",
 		},
 		{
 			name:    "truncates long detail",
@@ -41,7 +41,7 @@ func TestFormatIndicator(t *testing.T) {
 			name:   "escapes backticks in detail",
 			toolN:  "bash",
 			detail: "echo `whoami`",
-			want:   "_running bash:_ `echo 'whoami'`",
+			want:   "-# running bash: `echo 'whoami'`",
 		},
 	}
 


### PR DESCRIPTION
## What
Add a tool activity indicator to Discord so users see what tool the agent is running instead of just a typing indicator. The agent emits events when it begins executing tool calls, and the Discord bot listens to these events to create and update a live indicator message showing tool name and details.

## Changes
- Add `ToolEvent` and `ToolCallback` types to agent for signaling tool execution start
- Add `SetToolCallback()` and `emitToolEvent()` to Agent for per-user event notification
- Emit tool events during Chat() with tool name and formatted details
- Create `activityIndicator` in Discord bot that posts/updates a single metadata message per chat session
- Implement rate-limiting (~600ms between edits) to respect Discord API limits
- Format indicator as small muted text (`-# running toolname: details...`) with notification suppression
- Add tests for indicator formatting, truncation, and backtick escaping