### PR TITLE
feat(discord): indicator shows tool chain

### DIFF
--- a/discord/indicator.go
+++ b/discord/indicator.go
@@ -13,11 +13,16 @@ import (
 const (
 	indicatorMinInterval = 600 * time.Millisecond
 	indicatorMaxDetail   = 80
+	indicatorChainMax    = 3
 )
 
 // activityIndicator maintains a single Discord message that reflects the
-// currently running tool call. It creates the message lazily on the first
-// event, edits it on subsequent events, and deletes it on Close.
+// chain of tool calls in the current turn. It creates the message lazily on
+// the first event, edits it on subsequent events, and deletes it on Close.
+//
+// The chain shows up to indicatorChainMax most recent tool names joined with
+// an arrow, followed by the current tool's detail. Older tools fall off the
+// left as new ones arrive so the message stays compact on mobile.
 //
 // Discord rate-limits edits to roughly 5 per 5s per channel. We throttle to
 // one edit per ~600ms which keeps us well under that ceiling while staying
@@ -30,6 +35,7 @@ type activityIndicator struct {
 	messageID string
 	lastEdit  time.Time
 	closed    bool
+	chain     []string
 }
 
 func newActivityIndicator(s *discordgo.Session, channelID string) *activityIndicator {
@@ -47,7 +53,12 @@ func (a *activityIndicator) onEvent(ev agent.ToolEvent) {
 		return
 	}
 
-	content := formatIndicator(ev.Name, ev.Detail)
+	a.chain = append(a.chain, ev.Name)
+	if len(a.chain) > indicatorChainMax {
+		a.chain = a.chain[len(a.chain)-indicatorChainMax:]
+	}
+
+	content := formatChain(a.chain, ev.Detail)
 
 	if a.messageID == "" {
 		msg, err := a.session.ChannelMessageSendComplex(a.channelID, &discordgo.MessageSend{
@@ -87,17 +98,38 @@ func (a *activityIndicator) Close() {
 	a.messageID = ""
 }
 
-func formatIndicator(name, detail string) string {
+// formatChain renders the tool chain as subtext. Only the last (current) tool
+// carries its detail; earlier tools are shown by name only to keep the line
+// short on mobile.
+func formatChain(chain []string, detail string) string {
+	if len(chain) == 0 {
+		return ""
+	}
 	detail = strings.TrimSpace(detail)
-	// -# renders as small, muted subtext in Discord so the indicator reads as
-	// metadata rather than a regular message.
+
+	prefix := strings.Join(chain[:len(chain)-1], " → ")
+	current := chain[len(chain)-1]
+
+	var head string
+	if prefix == "" {
+		head = fmt.Sprintf("running %s", current)
+	} else {
+		head = fmt.Sprintf("%s → %s", prefix, current)
+	}
+
 	if detail == "" {
-		return fmt.Sprintf("-# running %s...", name)
+		return fmt.Sprintf("-# %s...", head)
 	}
 	if len(detail) > indicatorMaxDetail {
 		detail = detail[:indicatorMaxDetail] + "..."
 	}
-	return fmt.Sprintf("-# running %s: `%s`", name, escapeBackticks(detail))
+	return fmt.Sprintf("-# %s: `%s`", head, escapeBackticks(detail))
+}
+
+// formatIndicator is kept for backwards compatibility with existing tests and
+// single-tool callers. It renders a chain of length one.
+func formatIndicator(name, detail string) string {
+	return formatChain([]string{name}, detail)
 }
 
 // escapeBackticks prevents a detail that contains backticks from breaking out

--- a/discord/indicator_test.go
+++ b/discord/indicator_test.go
@@ -72,3 +72,51 @@ func TestFormatIndicator_RespectsMaxDetailLength(t *testing.T) {
 		t.Errorf("body length %d exceeds max+3 (%d): %q", len(body), indicatorMaxDetail+3, body)
 	}
 }
+
+func TestFormatChain(t *testing.T) {
+	tests := []struct {
+		name   string
+		chain  []string
+		detail string
+		want   string
+	}{
+		{
+			name:  "empty chain",
+			chain: []string{},
+			want:  "",
+		},
+		{
+			name:   "single tool no detail",
+			chain:  []string{"bash"},
+			detail: "",
+			want:   "-# running bash...",
+		},
+		{
+			name:   "two tools last has detail",
+			chain:  []string{"web_search", "web_read"},
+			detail: "https://example.com",
+			want:   "-# web_search → web_read: `https://example.com`",
+		},
+		{
+			name:   "three tools no detail",
+			chain:  []string{"web_search", "web_read", "file_write"},
+			detail: "",
+			want:   "-# web_search → web_read → file_write...",
+		},
+		{
+			name:   "prefix tools never show detail",
+			chain:  []string{"bash", "web_search"},
+			detail: "nevinho",
+			want:   "-# bash → web_search: `nevinho`",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatChain(tt.chain, tt.detail)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Discord indicator now keeps the last 3 tool names joined with arrows (`web_search → web_read → bash`) instead of overwriting with the latest tool on each event.
- Only the current (last) tool carries its detail; earlier entries are name-only to keep the line compact on mobile.
- Falls back cleanly to single-tool rendering via the existing `formatIndicator` shim.

## Why

Users were seeing only the last tool call during a chain (e.g. `web_search → web_read` for a job-listing query), making it look like one step when the agent was actually chaining. The new format shows the chain at a glance without extra messages.

## Test plan

- [ ] `go test ./discord/...` — added `TestFormatChain` cases (single, two, three tools; detail placement)
- [ ] Smoke-test in Discord with a multi-tool query (e.g. "show me jobs in Sion") and confirm arrow chain appears and stays silent on mobile