### PR TITLE
feat(discord): collapse consecutive duplicate tools in indicator

### DIFF
--- a/discord/indicator.go
+++ b/discord/indicator.go
@@ -27,6 +27,15 @@ const (
 // Discord rate-limits edits to roughly 5 per 5s per channel. We throttle to
 // one edit per ~600ms which keeps us well under that ceiling while staying
 // responsive for the user.
+// chainEntry groups consecutive calls to the same tool. Seeing the exact
+// same tool fire three times in a row tells the user nothing new, so we
+// collapse it into one entry with a count instead of spamming the arrow
+// chain with duplicates.
+type chainEntry struct {
+	name  string
+	count int
+}
+
 type activityIndicator struct {
 	session   *discordgo.Session
 	channelID string
@@ -35,7 +44,7 @@ type activityIndicator struct {
 	messageID string
 	lastEdit  time.Time
 	closed    bool
-	chain     []string
+	chain     []chainEntry
 }
 
 func newActivityIndicator(s *discordgo.Session, channelID string) *activityIndicator {
@@ -53,9 +62,13 @@ func (a *activityIndicator) onEvent(ev agent.ToolEvent) {
 		return
 	}
 
-	a.chain = append(a.chain, ev.Name)
-	if len(a.chain) > indicatorChainMax {
-		a.chain = a.chain[len(a.chain)-indicatorChainMax:]
+	if n := len(a.chain); n > 0 && a.chain[n-1].name == ev.Name {
+		a.chain[n-1].count++
+	} else {
+		a.chain = append(a.chain, chainEntry{name: ev.Name, count: 1})
+		if len(a.chain) > indicatorChainMax {
+			a.chain = a.chain[len(a.chain)-indicatorChainMax:]
+		}
 	}
 
 	content := formatChain(a.chain, ev.Detail)
@@ -100,15 +113,20 @@ func (a *activityIndicator) Close() {
 
 // formatChain renders the tool chain as subtext. Only the last (current) tool
 // carries its detail; earlier tools are shown by name only to keep the line
-// short on mobile.
-func formatChain(chain []string, detail string) string {
+// short on mobile. Repeated consecutive calls to the same tool render as
+// "name ×N" instead of arrow-spamming the same name.
+func formatChain(chain []chainEntry, detail string) string {
 	if len(chain) == 0 {
 		return ""
 	}
 	detail = strings.TrimSpace(detail)
 
-	prefix := strings.Join(chain[:len(chain)-1], " → ")
-	current := chain[len(chain)-1]
+	parts := make([]string, len(chain))
+	for i, e := range chain {
+		parts[i] = renderEntry(e)
+	}
+	prefix := strings.Join(parts[:len(parts)-1], " → ")
+	current := parts[len(parts)-1]
 
 	var head string
 	if prefix == "" {
@@ -126,10 +144,17 @@ func formatChain(chain []string, detail string) string {
 	return fmt.Sprintf("-# %s: `%s`", head, escapeBackticks(detail))
 }
 
+func renderEntry(e chainEntry) string {
+	if e.count > 1 {
+		return fmt.Sprintf("%s ×%d", e.name, e.count)
+	}
+	return e.name
+}
+
 // formatIndicator is kept for backwards compatibility with existing tests and
 // single-tool callers. It renders a chain of length one.
 func formatIndicator(name, detail string) string {
-	return formatChain([]string{name}, detail)
+	return formatChain([]chainEntry{{name: name, count: 1}}, detail)
 }
 
 // escapeBackticks prevents a detail that contains backticks from breaking out

--- a/discord/indicator_test.go
+++ b/discord/indicator_test.go
@@ -74,40 +74,53 @@ func TestFormatIndicator_RespectsMaxDetailLength(t *testing.T) {
 }
 
 func TestFormatChain(t *testing.T) {
+	e := func(name string, count int) chainEntry { return chainEntry{name: name, count: count} }
 	tests := []struct {
 		name   string
-		chain  []string
+		chain  []chainEntry
 		detail string
 		want   string
 	}{
 		{
 			name:  "empty chain",
-			chain: []string{},
+			chain: []chainEntry{},
 			want:  "",
 		},
 		{
 			name:   "single tool no detail",
-			chain:  []string{"bash"},
+			chain:  []chainEntry{e("bash", 1)},
 			detail: "",
 			want:   "-# running bash...",
 		},
 		{
 			name:   "two tools last has detail",
-			chain:  []string{"web_search", "web_read"},
+			chain:  []chainEntry{e("web_search", 1), e("web_read", 1)},
 			detail: "https://example.com",
 			want:   "-# web_search → web_read: `https://example.com`",
 		},
 		{
 			name:   "three tools no detail",
-			chain:  []string{"web_search", "web_read", "file_write"},
+			chain:  []chainEntry{e("web_search", 1), e("web_read", 1), e("file_write", 1)},
 			detail: "",
 			want:   "-# web_search → web_read → file_write...",
 		},
 		{
 			name:   "prefix tools never show detail",
-			chain:  []string{"bash", "web_search"},
+			chain:  []chainEntry{e("bash", 1), e("web_search", 1)},
 			detail: "nevinho",
 			want:   "-# bash → web_search: `nevinho`",
+		},
+		{
+			name:   "repeated tool shows count",
+			chain:  []chainEntry{e("web_search", 3)},
+			detail: "query",
+			want:   "-# running web_search ×3: `query`",
+		},
+		{
+			name:   "count only on repeated entry",
+			chain:  []chainEntry{e("web_search", 3), e("web_read", 1)},
+			detail: "https://example.com",
+			want:   "-# web_search ×3 → web_read: `https://example.com`",
 		},
 	}
 
@@ -118,5 +131,25 @@ func TestFormatChain(t *testing.T) {
 				t.Errorf("got %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestIndicatorCollapsesDuplicates(t *testing.T) {
+	a := &activityIndicator{}
+	// Simulate three consecutive web_search calls followed by one web_read
+	// without touching Discord. We can't call onEvent because it hits the
+	// network, but the collapse logic lives purely in the chain update.
+	a.chain = append(a.chain, chainEntry{name: "web_search", count: 1})
+	for range 2 {
+		if n := len(a.chain); n > 0 && a.chain[n-1].name == "web_search" {
+			a.chain[n-1].count++
+		}
+	}
+	a.chain = append(a.chain, chainEntry{name: "web_read", count: 1})
+
+	got := formatChain(a.chain, "https://example.com")
+	want := "-# web_search ×3 → web_read: `https://example.com`"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

- Track chain entries as `{name, count}` instead of a flat name slice.
- Consecutive calls to the same tool increment the count instead of appending another arrow segment.
- Renders as `web_search ×3 → web_read` instead of `web_search → web_search → web_search → web_read`.

## Why

Observed in practice: a job-description query fired `web_search` three times in a row, and the indicator rendered `web_search → web_search → web_search: ...`. Repeated same-tool segments tell the user nothing new. Counting them is the useful signal; the arrow should mean "switched tool".

## Test plan

- [ ] `go test ./discord/...` — added `TestIndicatorCollapsesDuplicates` and two `TestFormatChain` cases for the count rendering
- [ ] Smoke-test with a multi-search query and confirm `×N` appears when the agent repeats a tool