### PR TITLE
feat: persist conversations across restarts (ELEPHANT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Enable during `nevinho setup`. Requires `ffmpeg` and a C compiler (auto-installe
 
 | Command             | What it does                              |
 | ------------------- | ----------------------------------------- |
-| `/new`              | Start a fresh conversation                |
+| `/forget`           | Wipe this conversation and any saved summary |
 | `/model`            | Show current model with dropdown selector |
 | `/model <name>`     | Switch to a specific model                |
 | `/status`           | Uptime, token usage, model info           |
@@ -124,12 +124,15 @@ config.enc          encrypted configuration (AES-256-GCM)
 secret.key          auto-generated encryption key
 approved_paths.json persisted write permissions
 memory.md           learned user preferences
+summaries/          per-user conversation summaries (ELEPHANT)
 whisper/            local Whisper model and binary (if voice enabled)
 ```
 
 You can also use a `.env` file in the project directory for development. Env vars take priority over encrypted config.
 
 Set `CAVEMAN` to `on` via `/config` for a token-saving caveman-style response. Off by default.
+
+Set `ELEPHANT` to `off` via `/config` to disable conversation persistence across restarts. On by default. When on, nevinho summarizes your conversation on shutdown and reloads it on the next start so you can pick up where you left off.
 
 ## Project structure
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,6 +54,13 @@ Markdown files with YAML frontmatter in `~/.nevinho/skills/`. System prompt carr
   - [ ] Fail closed on DNS resolution failure.
   - [ ] Block metadata hostnames by name (`metadata.google.internal`, `metadata`) in addition to IP.
 
+### Reliability (24/7 unattended)
+
+Personal bot on a VPS. Silent failures are the worst kind.
+
+- [ ] Crash heartbeat. On boot after an unclean shutdown, DM the owner: `restarted after crash at <ts>, last seen <ts>`. Write a `last_alive` timestamp every minute. Compare on boot.
+- [ ] Log rotation. `nevinho logs` file grows unbounded today. Wire `logrotate` config (or in-process rotation) to cap size and keep N days. Ship the config in `install.sh`.
+
 ## Next
 
 Queued. Starts once Now lands.
@@ -97,13 +104,6 @@ Nevinho runs 24/7 on a VPS. Run prompts on a schedule and report back.
 - [ ] Non-interactive bash policy (allowlist mode) during scheduled runs since the approval flow cannot prompt.
 - [ ] Limits: max 10 schedules, min 5-minute interval, 5-minute timeout, no missed-run catch-up.
 
-### Conversation persistence
-
-Conversations survive restarts and upgrades.
-
-- [ ] Write per-user summaries to `~/.nevinho/summaries/{userID}.md` on trim or shutdown.
-- [ ] Next message from that user loads the summary as context preamble.
-
 ## Later
 
 Real but deferred. Ship when the above is solid or when a user hits the pain.
@@ -137,3 +137,4 @@ Real but deferred. Ship when the above is solid or when a user hits the pain.
 - [x] **Harness memory.** Auto-injected `memory.md`. Pattern-triggered writes ("remember X", "always X"). 20-entry cap with dedup.
 - [x] **Voice.** Discord voice notes through OpenAI Whisper to agent input. Supports ogg, mp3, wav, m4a, webm.
 - [x] **Web tooling.** Tavily advanced search and extract. Jina Reader fallback. Polite headers. Explicit error signaling. 429/5xx retries.
+- [x] **Conversation persistence (ELEPHANT).** On shutdown, summarize each user's history to `~/.nevinho/summaries/{userID}.md`. Reload as `[Previous conversation: ...]` preamble on next start. Default on, toggle via `ELEPHANT=off`. `/forget` wipes both in-memory history and the saved summary.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -190,6 +190,8 @@ func (a *Agent) Chat(userID, text string, isVoice bool) (string, error) {
 		prompt += "\n\n[Memory]\nThe user has told you these things. Follow them:\n" + mem
 	}
 
+	a.maybeLoadSummary(userID)
+
 	if evicted := a.appendHistory(userID, a.llm.FormatUserMessage(text)); len(evicted) > 2 {
 		a.summarizeAndPrepend(userID, evicted)
 	}
@@ -265,6 +267,81 @@ func (a *Agent) ClearHistory(userID string) {
 	lock.Lock()
 	defer lock.Unlock()
 	delete(a.history, userID)
+	if err := deleteSummary(a.cfg.Dir(), userID); err != nil {
+		logger.Err(fmt.Errorf("delete summary: %w", err))
+	}
+}
+
+// maybeLoadSummary injects the persisted summary into history if elephant is on
+// and this user has no in-memory history yet (fresh process start).
+func (a *Agent) maybeLoadSummary(userID string) {
+	if !a.cfg.ElephantEnabled() {
+		return
+	}
+	if len(a.history[userID]) > 0 {
+		return
+	}
+	summary := loadSummary(a.cfg.Dir(), userID)
+	if summary == "" {
+		return
+	}
+	preamble := a.llm.FormatUserMessage("[Previous conversation: " + summary + "]")
+	a.history[userID] = append(a.history[userID], preamble)
+	logger.Info("loaded persisted summary")
+}
+
+// PersistAll summarizes each active user's in-memory history and writes it to
+// disk. Called on shutdown so the next process start can resume context.
+// Respects the parent context for early cancellation; skips users on error so
+// one bad summary doesn't block the rest.
+func (a *Agent) PersistAll(ctx context.Context) {
+	if !a.cfg.ElephantEnabled() {
+		return
+	}
+	a.mu.Lock()
+	users := make([]string, 0, len(a.history))
+	for u := range a.history {
+		users = append(users, u)
+	}
+	a.mu.Unlock()
+
+	for _, userID := range users {
+		if ctx.Err() != nil {
+			logger.Info("persist cancelled, skipping remaining users")
+			return
+		}
+		a.persistUser(ctx, userID)
+	}
+}
+
+func (a *Agent) persistUser(ctx context.Context, userID string) {
+	a.mu.Lock()
+	msgs := a.history[userID]
+	a.mu.Unlock()
+	if len(msgs) == 0 {
+		return
+	}
+	flat := flattenMessages(msgs)
+	if flat == "" {
+		return
+	}
+	resp, err := a.llm.Complete(ctx, &llm.Request{
+		SystemPrompt: "Summarize this conversation in 3-5 sentences. Capture what the user was working on, key decisions, and unresolved threads. Be specific enough that the next session can pick up where this left off.",
+		Messages:     []json.RawMessage{a.llm.FormatUserMessage(flat)},
+		MaxTokens:    400,
+	})
+	if err != nil {
+		logger.Err(fmt.Errorf("persist summary for user: %w", err))
+		return
+	}
+	if resp.Text == "" {
+		return
+	}
+	if err := saveSummary(a.cfg.Dir(), userID, resp.Text); err != nil {
+		logger.Err(fmt.Errorf("save summary: %w", err))
+		return
+	}
+	logger.Info("persisted summary")
 }
 
 func (a *Agent) Model() string {

--- a/agent/persistence.go
+++ b/agent/persistence.go
@@ -1,0 +1,90 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	summariesDir   = "summaries"
+	summaryMaxSize = 4000 // ~1000 tokens, generous cap
+)
+
+// summaryPath returns the on-disk location for a user's persisted summary.
+// The userID is sanitized to prevent path traversal even though Discord IDs
+// are numeric snowflakes; we don't trust callers.
+func summaryPath(configDir, userID string) (string, error) {
+	clean := sanitizeUserID(userID)
+	if clean == "" {
+		return "", fmt.Errorf("invalid user id")
+	}
+	return filepath.Join(configDir, summariesDir, clean+".md"), nil
+}
+
+func sanitizeUserID(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return ""
+	}
+	if strings.ContainsAny(id, `/\.`) {
+		return ""
+	}
+	return filepath.Base(id)
+}
+
+// loadSummary reads a persisted summary for the user. Returns "" if missing.
+func loadSummary(configDir, userID string) string {
+	path, err := summaryPath(configDir, userID)
+	if err != nil {
+		return ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// saveSummary writes the summary atomically: write to .tmp then rename so a
+// crash mid-write can't leave a half-written file.
+func saveSummary(configDir, userID, text string) error {
+	path, err := summaryPath(configDir, userID)
+	if err != nil {
+		return err
+	}
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return deleteSummary(configDir, userID)
+	}
+	if len(text) > summaryMaxSize {
+		text = text[:summaryMaxSize]
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("create summaries dir: %w", err)
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(text+"\n"), 0644); err != nil {
+		return fmt.Errorf("write summary: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("rename summary: %w", err)
+	}
+	return nil
+}
+
+// deleteSummary removes the persisted summary. Missing file is not an error.
+func deleteSummary(configDir, userID string) error {
+	path, err := summaryPath(configDir, userID)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/agent/persistence.go
+++ b/agent/persistence.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	summariesDir   = "summaries"
-	summaryMaxSize = 4000 // ~1000 tokens, generous cap
+	summaryMaxSize = 4000 // ~1000 tokens
 )
 
 // summaryPath returns the on-disk location for a user's persisted summary.

--- a/agent/persistence_test.go
+++ b/agent/persistence_test.go
@@ -1,0 +1,123 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSummaryRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	userID := "123456789"
+
+	if got := loadSummary(dir, userID); got != "" {
+		t.Fatalf("expected empty for missing file, got %q", got)
+	}
+
+	want := "User was debugging the deploy script. Found a bug in env loading."
+	if err := saveSummary(dir, userID, want); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got := loadSummary(dir, userID)
+	if got != want {
+		t.Fatalf("roundtrip mismatch:\nwant: %q\ngot:  %q", want, got)
+	}
+
+	if err := deleteSummary(dir, userID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if got := loadSummary(dir, userID); got != "" {
+		t.Fatalf("expected empty after delete, got %q", got)
+	}
+}
+
+func TestSaveSummaryAtomic(t *testing.T) {
+	dir := t.TempDir()
+	userID := "123"
+
+	if err := saveSummary(dir, userID, "hello"); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	entries, err := os.ReadDir(filepath.Join(dir, summariesDir))
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Fatalf("leftover .tmp file: %s", e.Name())
+		}
+	}
+}
+
+func TestSaveSummaryEmptyDeletes(t *testing.T) {
+	dir := t.TempDir()
+	userID := "123"
+
+	if err := saveSummary(dir, userID, "real content"); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if err := saveSummary(dir, userID, "   "); err != nil {
+		t.Fatalf("save empty: %v", err)
+	}
+	if got := loadSummary(dir, userID); got != "" {
+		t.Fatalf("empty save should remove file, got %q", got)
+	}
+}
+
+func TestSaveSummaryTruncates(t *testing.T) {
+	dir := t.TempDir()
+	userID := "123"
+
+	huge := strings.Repeat("x", summaryMaxSize*2)
+	if err := saveSummary(dir, userID, huge); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got := loadSummary(dir, userID)
+	if len(got) > summaryMaxSize {
+		t.Fatalf("expected truncation to %d, got %d", summaryMaxSize, len(got))
+	}
+}
+
+func TestSanitizeUserIDRejectsTraversal(t *testing.T) {
+	bad := []string{
+		"",
+		"  ",
+		"../etc/passwd",
+		"foo/bar",
+		"foo.bar",
+		`foo\bar`,
+	}
+	for _, id := range bad {
+		if got := sanitizeUserID(id); got != "" {
+			t.Errorf("expected reject for %q, got %q", id, got)
+		}
+	}
+
+	good := []string{
+		"123456789",
+		"abc123",
+		"user_42",
+	}
+	for _, id := range good {
+		if got := sanitizeUserID(id); got != id {
+			t.Errorf("expected pass for %q, got %q", id, got)
+		}
+	}
+}
+
+func TestDeleteSummaryMissingIsNotError(t *testing.T) {
+	dir := t.TempDir()
+	if err := deleteSummary(dir, "nonexistent"); err != nil {
+		t.Fatalf("delete missing should not error, got: %v", err)
+	}
+}
+
+func TestSaveSummaryRejectsBadUserID(t *testing.T) {
+	dir := t.TempDir()
+	if err := saveSummary(dir, "../escape", "content"); err == nil {
+		t.Fatal("expected error for path traversal user id")
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	TavilyAPIKey    string `json:"tavily_api_key"`
 	Model           string `json:"model"`
 	Caveman         string `json:"caveman"`
+	Elephant        string `json:"elephant"`
 }
 
 // keymap maps user-facing key names to struct field pointers.
@@ -38,6 +39,7 @@ func (c *Config) keymap() map[string]*string {
 		"TAVILY_API_KEY":    &c.TavilyAPIKey,
 		"MODEL":             &c.Model,
 		"CAVEMAN":           &c.Caveman,
+		"ELEPHANT":          &c.Elephant,
 	}
 }
 
@@ -118,6 +120,16 @@ func (c *Config) Set(key, value string) error {
 			return fmt.Errorf("CAVEMAN must be on or off")
 		}
 	}
+	if key == "ELEPHANT" {
+		switch strings.ToLower(value) {
+		case "", "on":
+			value = ""
+		case "off":
+			value = "off"
+		default:
+			return fmt.Errorf("ELEPHANT must be on or off")
+		}
+	}
 	c.mu.Lock()
 	field, ok := c.keymap()[key]
 	if !ok {
@@ -140,7 +152,7 @@ func (c *Config) Keys() []KeyStatus {
 	order := []string{
 		"DISCORD_BOT_TOKEN", "DISCORD_OWNER_ID",
 		"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OLLAMA_MODEL",
-		"TAVILY_API_KEY", "MODEL", "CAVEMAN",
+		"TAVILY_API_KEY", "MODEL", "CAVEMAN", "ELEPHANT",
 	}
 
 	km := c.keymap()
@@ -159,6 +171,14 @@ func (c *Config) Keys() []KeyStatus {
 }
 
 func (c *Config) Dir() string { return c.dir }
+
+// ElephantEnabled reports whether conversation persistence is on. Default is on:
+// only an explicit "off" disables it. Named after elephants, who never forget.
+func (c *Config) ElephantEnabled() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return strings.ToLower(c.Elephant) != "off"
+}
 
 // CavemanPrompt returns the style block to prepend to the system prompt.
 // Any non-empty, non-"off" value enables it (accepts legacy lite/full/ultra).

--- a/discord/bot.go
+++ b/discord/bot.go
@@ -67,8 +67,8 @@ var slashCommands = []*discordgo.ApplicationCommand{
 		Description: "Cancel the current operation",
 	},
 	{
-		Name:        "new",
-		Description: "Start a fresh conversation",
+		Name:        "forget",
+		Description: "Wipe this conversation and any persisted summary",
 	},
 	{
 		Name:        "model",
@@ -180,9 +180,9 @@ func (b *Bot) onInteraction(s *discordgo.Session, i *discordgo.InteractionCreate
 			reply = "Nothing running."
 		}
 
-	case "new":
+	case "forget":
 		b.agent.ClearHistory(userID)
-		reply = "Fresh conversation started."
+		reply = "Forgotten. Fresh thread."
 
 	case "help":
 		reply = helpMessage()
@@ -283,9 +283,9 @@ func (b *Bot) onMessage(s *discordgo.Session, m *discordgo.MessageCreate) {
 			s.ChannelMessageSend(m.ChannelID, "Nothing running.")
 		}
 		return
-	case lower == "/new":
+	case lower == "/forget":
 		b.agent.ClearHistory(m.Author.ID)
-		s.ChannelMessageSend(m.ChannelID, "Fresh conversation started.")
+		s.ChannelMessageSend(m.ChannelID, "Forgotten. Fresh thread.")
 		return
 	case lower == "/help":
 		s.ChannelMessageSend(m.ChannelID, helpMessage())
@@ -876,7 +876,7 @@ func helpMessage() string {
 
 **Commands:**
 ` + "`/cancel`" + ` cancel current operation
-` + "`/new`" + ` fresh conversation
+` + "`/forget`" + ` wipe this conversation
 ` + "`/model`" + ` show or switch model
 ` + "`/status`" + ` uptime, tokens, cost
 ` + "`/paths`" + ` manage approved write paths

--- a/main.go
+++ b/main.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/joho/godotenv"
 	"github.com/lucasnevespereira/nevinho/agent"
@@ -87,6 +89,11 @@ func run(configDir string) {
 	<-stop
 
 	logger.Info("shutting down...")
+
+	persistCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	a.PersistAll(persistCtx)
+	cancel()
+
 	bot.Stop()
 }
 


### PR DESCRIPTION
## What

Add conversation persistence (ELEPHANT) so nevinho resumes context after restarts. On shutdown, summaries of each user's conversation history are written to `~/.nevinho/summaries/{userID}.md`. On next start, the agent injects the summary as context preamble so you pick up where you left off. Disabled with `ELEPHANT=off` via `/config`.

## Changes

- New `persistence.go` with functions to save/load/delete per-user conversation summaries atomically
- `Agent.PersistAll()` summarizes each active user's in-memory history via LLM on shutdown (30s timeout, graceful skip on error)
- `Agent.maybeLoadSummary()` injects persisted summary on first message from a user after process start
- `Agent.ClearHistory()` now also deletes the saved summary
- Replaced `/new` command with `/forget` to clarify it wipes both in-memory history and saved summary
- New `ELEPHANT` config key (default on, set to `off` to disable)
- Updated README with command reference and config directory structure
- Moved conversation persistence from ROADMAP "Next" section to "Completed"