### PR TITLE
fix(tools): cancel kill bash children and approved code

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -151,7 +151,7 @@ func (a *Agent) Chat(userID, text string, isVoice bool) (string, error) {
 			text = text + "\n[Access granted to " + p.Detail + ". Retry the file operation.]"
 		case "code":
 			logger.Info("approved: code execution")
-			output := a.tools.ExecutePendingCode(userID)
+			output := a.tools.ExecutePendingCode(ctx, userID)
 			text = text + "\n[Code execution approved. Output:\n" + output + "]"
 		}
 	}

--- a/tools/bash.go
+++ b/tools/bash.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -112,6 +113,15 @@ func (r *Registry) executeBashCtx(parent context.Context, command string) string
 	// Force no-color output to avoid wasting tokens on ANSI codes
 	cmd := exec.CommandContext(ctx, "bash", "-c", command)
 	cmd.Env = append(os.Environ(), "NO_COLOR=1", "TERM=dumb")
+	// Run in its own process group so cancel can SIGKILL the whole tree.
+	// Without this, children like `python3 -m http.server` outlive the bash parent.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
 	output, err := cmd.CombinedOutput()
 	result := stripANSI(string(output))
 
@@ -144,12 +154,12 @@ func (r *Registry) executeBashCtx(parent context.Context, command string) string
 }
 
 // executePendingBash runs a command after user approval.
-func (r *Registry) executePendingBash(input json.RawMessage) string {
+func (r *Registry) executePendingBash(ctx context.Context, input json.RawMessage) string {
 	var in bashInput
 	if err := json.Unmarshal(input, &in); err != nil {
 		return fmt.Sprintf("invalid input: %v", err)
 	}
-	return r.executeBashCtx(context.Background(), in.Command)
+	return r.executeBashCtx(ctx, in.Command)
 }
 
 // isDangerous returns a reason string if the command needs approval, empty otherwise.

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -285,7 +285,7 @@ func (r *Registry) ApprovePending(userID string) {
 	delete(r.pending, userID)
 }
 
-func (r *Registry) ExecutePendingCode(userID string) string {
+func (r *Registry) ExecutePendingCode(ctx context.Context, userID string) string {
 	r.mu.Lock()
 	p := r.pending[userID]
 	r.mu.Unlock()
@@ -295,7 +295,7 @@ func (r *Registry) ExecutePendingCode(userID string) string {
 	r.mu.Lock()
 	delete(r.pending, userID)
 	r.mu.Unlock()
-	return r.executePendingBash(p.Code.Input)
+	return r.executePendingBash(ctx, p.Code.Input)
 }
 
 func (r *Registry) checkWritePermission(resolved, userID string) error {


### PR DESCRIPTION
## What

`/cancel` sometimes returned "Cancelled." while the spawned process kept running and the per-user lock stayed held, so the next message looked ignored. Two bugs combined to cause this.

First, `tools.executePendingBash` ran the approved command with `context.Background()`, fully detached from the per-user cancel context. Approved commands were uncancellable.

Second, `executeBashCtx` used `exec.CommandContext` without a process group, so cancel SIGKILL'd the `bash -c` parent but left children (e.g. `python3 -m http.server`) re-parented to init and still holding ports.

## Changes

- `tools/bash.go`: set `Setpgid: true` and override `cmd.Cancel` to `syscall.Kill(-pid, SIGKILL)` so the whole tree dies on cancel.
- `tools/bash.go`, `tools/registry.go`, `agent/agent.go`: thread the per-user `ctx` through `ExecutePendingCode` → `executePendingBash` so approved code respects `/cancel` like every other tool call.