### PR TITLE
fix(agent): break approval loop after deferred code execution

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -65,11 +65,12 @@ type Agent struct {
 	version string
 	selfDoc string
 
-	mu        sync.Mutex
-	history   map[string][]json.RawMessage
-	userLock  map[string]*sync.Mutex
-	cancelFn  map[string]context.CancelFunc
-	toolCb    map[string]ToolCallback
+	mu             sync.Mutex
+	history        map[string][]json.RawMessage
+	userLock       map[string]*sync.Mutex
+	cancelFn       map[string]context.CancelFunc
+	toolCb         map[string]ToolCallback
+	pendingToolID  map[string]string
 	startTime time.Time
 	tokensIn  int
 	tokensOut int
@@ -77,16 +78,17 @@ type Agent struct {
 
 func New(provider llm.Provider, cfg *config.Config, version, selfDoc string) *Agent {
 	return &Agent{
-		llm:       provider,
-		tools:     tools.NewRegistry(cfg),
-		cfg:       cfg,
-		version:   version,
-		selfDoc:   strings.TrimSpace(selfDoc),
-		history:   make(map[string][]json.RawMessage),
-		userLock:  make(map[string]*sync.Mutex),
-		cancelFn:  make(map[string]context.CancelFunc),
-		toolCb:    make(map[string]ToolCallback),
-		startTime: time.Now(),
+		llm:           provider,
+		tools:         tools.NewRegistry(cfg),
+		cfg:           cfg,
+		version:       version,
+		selfDoc:       strings.TrimSpace(selfDoc),
+		history:       make(map[string][]json.RawMessage),
+		userLock:      make(map[string]*sync.Mutex),
+		cancelFn:      make(map[string]context.CancelFunc),
+		toolCb:        make(map[string]ToolCallback),
+		pendingToolID: make(map[string]string),
+		startTime:     time.Now(),
 	}
 }
 
@@ -152,6 +154,7 @@ func (a *Agent) Chat(userID, text string, isVoice bool) (string, error) {
 		case "code":
 			logger.Info("approved: code execution")
 			output := a.tools.ExecutePendingCode(ctx, userID)
+			a.replacePendingToolResult(userID, output)
 			text = text + "\n[Code execution approved. Output:\n" + output + "]"
 		}
 	}
@@ -245,6 +248,9 @@ func (a *Agent) Chat(userID, text string, isVoice bool) (string, error) {
 			results = append(results, result)
 			if strings.HasPrefix(output, "NEEDS_APPROVAL:") {
 				needsApproval = true
+				a.mu.Lock()
+				a.pendingToolID[userID] = tc.ID
+				a.mu.Unlock()
 			}
 		}
 
@@ -312,6 +318,9 @@ func (a *Agent) ClearHistory(userID string) {
 	lock.Lock()
 	defer lock.Unlock()
 	delete(a.history, userID)
+	a.mu.Lock()
+	delete(a.pendingToolID, userID)
+	a.mu.Unlock()
 	if err := deleteSummary(a.cfg.Dir(), userID); err != nil {
 		logger.Err(fmt.Errorf("delete summary: %w", err))
 	}
@@ -508,6 +517,25 @@ func (a *Agent) appendHistory(userID string, msgs ...json.RawMessage) (evicted [
 	copy(evicted, a.history[userID][:evictedCount])
 	a.history[userID] = trimmed
 	return evicted
+}
+
+// replacePendingToolResult swaps the stale NEEDS_APPROVAL placeholder in
+// history with the real output once the user approves. Without this the LLM
+// sees the original tool_use as never-executed and re-emits it, causing an
+// approval loop.
+func (a *Agent) replacePendingToolResult(userID, output string) {
+	a.mu.Lock()
+	id := a.pendingToolID[userID]
+	delete(a.pendingToolID, userID)
+	hist := a.history[userID]
+	a.mu.Unlock()
+	if id == "" || len(hist) == 0 {
+		return
+	}
+	updated := a.llm.ReplaceToolResult(hist, id, output)
+	a.mu.Lock()
+	a.history[userID] = updated
+	a.mu.Unlock()
 }
 
 func (a *Agent) executeTool(ctx context.Context, name string, input json.RawMessage, userID string) (output string) {

--- a/llm/anthropic.go
+++ b/llm/anthropic.go
@@ -112,6 +112,39 @@ func (a *Anthropic) FormatUserMessage(text string) json.RawMessage {
 	return msg
 }
 
+func (a *Anthropic) ReplaceToolResult(history []json.RawMessage, toolUseID, newOutput string) []json.RawMessage {
+	for i := len(history) - 1; i >= 0; i-- {
+		var msg struct {
+			Role    string                   `json:"role"`
+			Content []map[string]interface{} `json:"content"`
+		}
+		if err := json.Unmarshal(history[i], &msg); err != nil {
+			continue
+		}
+		if msg.Role != "user" {
+			continue
+		}
+		changed := false
+		for j, block := range msg.Content {
+			if block["type"] != "tool_result" {
+				continue
+			}
+			if id, _ := block["tool_use_id"].(string); id == toolUseID {
+				msg.Content[j]["content"] = newOutput
+				delete(msg.Content[j], "is_error")
+				changed = true
+			}
+		}
+		if changed {
+			if rebuilt, err := json.Marshal(msg); err == nil {
+				history[i] = rebuilt
+			}
+			return history
+		}
+	}
+	return history
+}
+
 func (a *Anthropic) FormatToolResults(results []ToolResult) []json.RawMessage {
 	var content []interface{}
 	for _, r := range results {

--- a/llm/openai.go
+++ b/llm/openai.go
@@ -95,6 +95,27 @@ func (o *OpenAI) FormatUserMessage(text string) json.RawMessage {
 	return msg
 }
 
+func (o *OpenAI) ReplaceToolResult(history []json.RawMessage, toolUseID, newOutput string) []json.RawMessage {
+	for i := len(history) - 1; i >= 0; i-- {
+		var msg map[string]interface{}
+		if err := json.Unmarshal(history[i], &msg); err != nil {
+			continue
+		}
+		if role, _ := msg["role"].(string); role != "tool" {
+			continue
+		}
+		if id, _ := msg["tool_call_id"].(string); id != toolUseID {
+			continue
+		}
+		msg["content"] = newOutput
+		if rebuilt, err := json.Marshal(msg); err == nil {
+			history[i] = rebuilt
+		}
+		return history
+	}
+	return history
+}
+
 func (o *OpenAI) FormatToolResults(results []ToolResult) []json.RawMessage {
 	var msgs []json.RawMessage
 	for _, r := range results {

--- a/llm/provider.go
+++ b/llm/provider.go
@@ -13,6 +13,10 @@ type Provider interface {
 	Complete(ctx context.Context, req *Request) (*Response, error)
 	FormatUserMessage(text string) json.RawMessage
 	FormatToolResults(results []ToolResult) []json.RawMessage
+	// ReplaceToolResult swaps the stored output of a prior tool_result for the
+	// given tool-use id. Used after deferred approval so the LLM sees the
+	// actual executed output instead of the stale NEEDS_APPROVAL placeholder.
+	ReplaceToolResult(history []json.RawMessage, toolUseID, newOutput string) []json.RawMessage
 	Model() string
 }
 


### PR DESCRIPTION
## What

After approving a destructive command, Nevinho would re-prompt for the same approval in a loop. The model saw its own prior `tool_use` paired with a `NEEDS_APPROVAL` tool_result still sitting in history, concluded the command never ran, and re-emitted it. The next round hit the approval gate again.

The actual execution did happen, but the result was only stitched into the next user message as plain text (`[Code execution approved. Output: ...]`). The tool_use chain stayed broken.

Fix: when approval comes in, replace the placeholder tool_result in history with the real output, keyed by the original `tool_use_id`. The model now sees a clean executed call and moves on.

## Changes

- `llm/provider.go`: add `ReplaceToolResult(history, toolUseID, newOutput)` to the Provider interface.
- `llm/anthropic.go`, `llm/openai.go`: provider-specific implementations (Anthropic merges blocks inside one user message; OpenAI uses separate `role: tool` entries).
- `agent/agent.go`: track `pendingToolID` per user when `NEEDS_APPROVAL` fires, call `ReplaceToolResult` on the code-approval path, clear on `ClearHistory`.