### PR TITLE
feat(llm): openrouter provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # nevinho
 
 A minimal personal AI harness that runs in your Discord DMs.
-Supports Anthropic, OpenAI, and Ollama.
+Supports Anthropic, OpenAI, OpenRouter, and Ollama.
 Comes with tools for bash, code search, web search, and file management.
 
 ## Install
@@ -57,13 +57,20 @@ See [setup.md](setup.md) for Discord bot creation steps.
 
 Configure one or more LLM backends during setup:
 
-| Provider  | Env var               | Default model    |
-| --------- | --------------------- | ---------------- |
-| Anthropic | `ANTHROPIC_API_KEY`   | claude-haiku-4-5 |
-| OpenAI    | `OPENAI_API_KEY`      | gpt-4o-mini      |
-| Ollama    | `OLLAMA_MODEL=llama3` | any local model  |
+| Provider   | Env var                | Default model       |
+| ---------- | ---------------------- | ------------------- |
+| Anthropic  | `ANTHROPIC_API_KEY`    | claude-haiku-4-5    |
+| OpenAI     | `OPENAI_API_KEY`       | gpt-4o-mini         |
+| OpenRouter | `OPENROUTER_API_KEY`   | any supported model |
+| Ollama     | `OLLAMA_MODEL=llama3`   | any local model     |
 
-On startup, nevinho uses your last selected model. If none is saved, it picks the first available: Ollama > Anthropic > OpenAI.
+On startup, nevinho uses your last selected model. If none is saved, it picks `DEFAULT_PROVIDER` when set. Else legacy order: Ollama > OpenRouter > OpenAI > Anthropic.
+
+Prefix model names for exact provider:
+- `openrouter:claude-sonnet-4-5`
+- `openai:gpt-4o-mini`
+- `anthropic:claude-haiku-4-5`
+- `ollama:llama3`
 
 Switch models at runtime with `/model` (dropdown selector) or `/model <name>`.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -71,6 +71,7 @@ One file covers Groq, Together, OpenRouter, LM Studio, vLLM, local servers.
 
 - [ ] `llm/compat.go` pointing at any URL via `OPENAI_COMPAT_URL`, `OPENAI_COMPAT_KEY`, `OPENAI_COMPAT_MODEL`.
 - [ ] `nevinho setup` offers the new provider with presets for Groq, OpenRouter, LM Studio.
+- [ ] OpenRouter preset: default model picker, auth key field, docs note on paid/free models.
 
 ### CLI mode (`nevinho chat`)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -72,6 +72,9 @@ One file covers Groq, Together, OpenRouter, LM Studio, vLLM, local servers.
 - [ ] `llm/compat.go` pointing at any URL via `OPENAI_COMPAT_URL`, `OPENAI_COMPAT_KEY`, `OPENAI_COMPAT_MODEL`.
 - [ ] `nevinho setup` offers the new provider with presets for Groq, OpenRouter, LM Studio.
 - [ ] OpenRouter preset: default model picker, auth key field, docs note on paid/free models.
+- [x] OpenRouter key wiring in config + provider resolve.
+- [x] `DEFAULT_PROVIDER` for user-friendly no-prefix routing.
+- [x] Prefix routing: `openrouter:`, `openai:`, `anthropic:`, `ollama:`.
 
 ### CLI mode (`nevinho chat`)
 

--- a/config/config.go
+++ b/config/config.go
@@ -22,11 +22,12 @@ type Config struct {
 	AnthropicAPIKey  string `json:"anthropic_api_key"`
 	OpenAIAPIKey     string `json:"openai_api_key"`
 	OpenRouterAPIKey string `json:"openrouter_api_key"`
-	OllamaModel     string `json:"ollama_model"`
-	TavilyAPIKey    string `json:"tavily_api_key"`
-	Model           string `json:"model"`
-	Caveman         string `json:"caveman"`
-	Elephant        string `json:"elephant"`
+	OllamaModel      string `json:"ollama_model"`
+	TavilyAPIKey     string `json:"tavily_api_key"`
+	Model            string `json:"model"`
+	DefaultProvider   string `json:"default_provider"`
+	Caveman          string `json:"caveman"`
+	Elephant         string `json:"elephant"`
 }
 
 // keymap maps user-facing key names to struct field pointers.
@@ -40,6 +41,7 @@ func (c *Config) keymap() map[string]*string {
 		"OLLAMA_MODEL":      &c.OllamaModel,
 		"TAVILY_API_KEY":    &c.TavilyAPIKey,
 		"MODEL":             &c.Model,
+		"DEFAULT_PROVIDER":  &c.DefaultProvider,
 		"CAVEMAN":           &c.Caveman,
 		"ELEPHANT":          &c.Elephant,
 	}
@@ -154,7 +156,7 @@ func (c *Config) Keys() []KeyStatus {
 	order := []string{
 		"DISCORD_BOT_TOKEN", "DISCORD_OWNER_ID",
 		"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY", "OLLAMA_MODEL",
-		"TAVILY_API_KEY", "MODEL", "CAVEMAN", "ELEPHANT",
+		"TAVILY_API_KEY", "MODEL", "DEFAULT_PROVIDER", "CAVEMAN", "ELEPHANT",
 	}
 
 	km := c.keymap()
@@ -212,15 +214,17 @@ type ProviderConfig struct {
 	OpenAIKey      string
 	OpenRouterKey  string
 	OllamaURL      string
+	DefaultProvider string
 }
 
 func (c *Config) ProviderConfig() ProviderConfig {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	pc := ProviderConfig{
-		AnthropicKey:   c.AnthropicAPIKey,
-		OpenAIKey:      c.OpenAIAPIKey,
-		OpenRouterKey:  c.OpenRouterAPIKey,
+		AnthropicKey:    c.AnthropicAPIKey,
+		OpenAIKey:       c.OpenAIAPIKey,
+		OpenRouterKey:   c.OpenRouterAPIKey,
+		DefaultProvider: c.DefaultProvider,
 	}
 	if c.OllamaModel != "" {
 		pc.OllamaURL = "http://localhost:11434"

--- a/config/config.go
+++ b/config/config.go
@@ -19,8 +19,9 @@ type Config struct {
 
 	DiscordBotToken string `json:"discord_bot_token"`
 	DiscordOwnerID  string `json:"discord_owner_id"`
-	AnthropicAPIKey string `json:"anthropic_api_key"`
-	OpenAIAPIKey    string `json:"openai_api_key"`
+	AnthropicAPIKey  string `json:"anthropic_api_key"`
+	OpenAIAPIKey     string `json:"openai_api_key"`
+	OpenRouterAPIKey string `json:"openrouter_api_key"`
 	OllamaModel     string `json:"ollama_model"`
 	TavilyAPIKey    string `json:"tavily_api_key"`
 	Model           string `json:"model"`
@@ -33,8 +34,9 @@ func (c *Config) keymap() map[string]*string {
 	return map[string]*string{
 		"DISCORD_BOT_TOKEN": &c.DiscordBotToken,
 		"DISCORD_OWNER_ID":  &c.DiscordOwnerID,
-		"ANTHROPIC_API_KEY": &c.AnthropicAPIKey,
-		"OPENAI_API_KEY":    &c.OpenAIAPIKey,
+		"ANTHROPIC_API_KEY":  &c.AnthropicAPIKey,
+		"OPENAI_API_KEY":     &c.OpenAIAPIKey,
+		"OPENROUTER_API_KEY": &c.OpenRouterAPIKey,
 		"OLLAMA_MODEL":      &c.OllamaModel,
 		"TAVILY_API_KEY":    &c.TavilyAPIKey,
 		"MODEL":             &c.Model,
@@ -151,7 +153,7 @@ func (c *Config) Keys() []KeyStatus {
 
 	order := []string{
 		"DISCORD_BOT_TOKEN", "DISCORD_OWNER_ID",
-		"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OLLAMA_MODEL",
+		"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY", "OLLAMA_MODEL",
 		"TAVILY_API_KEY", "MODEL", "CAVEMAN", "ELEPHANT",
 	}
 
@@ -206,17 +208,19 @@ Examples:
 }
 
 type ProviderConfig struct {
-	AnthropicKey string
-	OpenAIKey    string
-	OllamaURL    string
+	AnthropicKey   string
+	OpenAIKey      string
+	OpenRouterKey  string
+	OllamaURL      string
 }
 
 func (c *Config) ProviderConfig() ProviderConfig {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	pc := ProviderConfig{
-		AnthropicKey: c.AnthropicAPIKey,
-		OpenAIKey:    c.OpenAIAPIKey,
+		AnthropicKey:   c.AnthropicAPIKey,
+		OpenAIKey:      c.OpenAIAPIKey,
+		OpenRouterKey:  c.OpenRouterAPIKey,
 	}
 	if c.OllamaModel != "" {
 		pc.OllamaURL = "http://localhost:11434"

--- a/config/setup.go
+++ b/config/setup.go
@@ -47,7 +47,7 @@ func RunSetup(configDir string) error {
 	}
 
 	// Show hint only on re-run (when some values already exist)
-	if cfg.DiscordBotToken != "" || cfg.AnthropicAPIKey != "" || cfg.OpenAIAPIKey != "" {
+	if cfg.DiscordBotToken != "" || cfg.AnthropicAPIKey != "" || cfg.OpenAIAPIKey != "" || cfg.OpenRouterAPIKey != "" {
 		fmt.Println("Press Enter to keep current value, - to clear.")
 		fmt.Println()
 	}
@@ -62,10 +62,11 @@ func RunSetup(configDir string) error {
 	fmt.Println("LLM providers")
 	cfg.AnthropicAPIKey = prompt("Anthropic API key", cfg.AnthropicAPIKey)
 	cfg.OpenAIAPIKey = prompt("OpenAI API key", cfg.OpenAIAPIKey)
+	cfg.OpenRouterAPIKey = prompt("OpenRouter API key", cfg.OpenRouterAPIKey)
 	cfg.OllamaModel = prompt("Ollama model (e.g. llama3)", cfg.OllamaModel)
 
 	// Warn if no provider
-	if cfg.AnthropicAPIKey == "" && cfg.OpenAIAPIKey == "" && cfg.OllamaModel == "" {
+	if cfg.AnthropicAPIKey == "" && cfg.OpenAIAPIKey == "" && cfg.OpenRouterAPIKey == "" && cfg.OllamaModel == "" {
 		fmt.Println()
 		fmt.Println("  Warning: no LLM provider configured. nevinho needs at least one.")
 	}
@@ -98,6 +99,7 @@ func RunSetup(configDir string) error {
 	printStatus("  Discord", cfg.DiscordBotToken != "" && cfg.DiscordOwnerID != "")
 	printStatus("  Anthropic", cfg.AnthropicAPIKey != "")
 	printStatus("  OpenAI", cfg.OpenAIAPIKey != "")
+	printStatus("  OpenRouter", cfg.OpenRouterAPIKey != "")
 	printStatus("  Ollama", cfg.OllamaModel != "")
 	printStatus("  Tavily Search", cfg.TavilyAPIKey != "")
 	printStatus("  Voice", voice.IsAvailable(whisperDir))

--- a/config/setup.go
+++ b/config/setup.go
@@ -75,6 +75,7 @@ func RunSetup(configDir string) error {
 	fmt.Println()
 	fmt.Println("Optional")
 	cfg.TavilyAPIKey = prompt("Tavily Search API key", cfg.TavilyAPIKey)
+	cfg.DefaultProvider = prompt("Default provider (openrouter/openai/anthropic/ollama)", cfg.DefaultProvider)
 
 	// Voice messages
 	fmt.Println()
@@ -102,6 +103,7 @@ func RunSetup(configDir string) error {
 	printStatus("  OpenRouter", cfg.OpenRouterAPIKey != "")
 	printStatus("  Ollama", cfg.OllamaModel != "")
 	printStatus("  Tavily Search", cfg.TavilyAPIKey != "")
+	printStatus("  Default provider", cfg.DefaultProvider != "")
 	printStatus("  Voice", voice.IsAvailable(whisperDir))
 
 	fmt.Println()

--- a/llm/openrouter.go
+++ b/llm/openrouter.go
@@ -1,0 +1,114 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type OpenRouter struct {
+	apiKey  string
+	baseURL string
+	model   string
+}
+
+func NewOpenRouter(apiKey, baseURL, model string) *OpenRouter {
+	if baseURL == "" {
+		baseURL = "https://openrouter.ai"
+	}
+	if model == "" {
+		model = "moonshotai/kimi-k2"
+	}
+	return &OpenRouter{apiKey: apiKey, baseURL: baseURL, model: model}
+}
+
+func (o *OpenRouter) Model() string { return o.model }
+
+func (o *OpenRouter) Complete(ctx context.Context, req *Request) (*Response, error) {
+	sysMsg, _ := json.Marshal(map[string]interface{}{
+		"role": "system", "content": req.SystemPrompt,
+	})
+	messages := append([]json.RawMessage{sysMsg}, ensureSlice(req.Messages)...)
+
+	body := map[string]interface{}{
+		"model":    o.model,
+		"messages": messages,
+		"tools":    o.formatTools(req.Tools),
+	}
+	if req.MaxTokens > 0 {
+		body["max_tokens"] = req.MaxTokens
+	}
+
+	data, err := doHTTP(ctx, o.baseURL+"/api/v1/chat/completions", body, map[string]string{
+		"Authorization": "Bearer " + o.apiKey,
+		"Content-Type":  "application/json",
+		"HTTP-Referer":   "https://github.com/lucasnevespereira/nevinho",
+		"X-Title":        "nevinho",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var raw struct {
+		Choices []struct {
+			Message struct {
+				Role      string          `json:"role"`
+				Content   *string         `json:"content"`
+				ToolCalls []openAIToolCall `json:"tool_calls"`
+			} `json:"message"`
+		} `json:"choices"`
+		Usage struct {
+			PromptTokens     int `json:"prompt_tokens"`
+			CompletionTokens int `json:"completion_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	if len(raw.Choices) == 0 {
+		return nil, fmt.Errorf("no choices in response")
+	}
+
+	choice := raw.Choices[0]
+	resp := &Response{Usage: Usage{In: raw.Usage.PromptTokens, Out: raw.Usage.CompletionTokens}}
+	assistantMsg, _ := json.Marshal(choice.Message)
+	resp.AssistantMessage = assistantMsg
+	if choice.Message.Content != nil {
+		resp.Text = *choice.Message.Content
+	}
+	for _, tc := range choice.Message.ToolCalls {
+		resp.ToolCalls = append(resp.ToolCalls, ToolCall{ID: tc.ID, Name: tc.Function.Name, Input: json.RawMessage(tc.Function.Arguments)})
+	}
+	return resp, nil
+}
+
+func (o *OpenRouter) FormatUserMessage(text string) json.RawMessage {
+	msg, _ := json.Marshal(map[string]interface{}{"role": "user", "content": text})
+	return msg
+}
+
+func (o *OpenRouter) ReplaceToolResult(history []json.RawMessage, toolUseID, newOutput string) []json.RawMessage {
+	return (&OpenAI{}).ReplaceToolResult(history, toolUseID, newOutput)
+}
+
+func (o *OpenRouter) FormatToolResults(results []ToolResult) []json.RawMessage {
+	return (&OpenAI{}).FormatToolResults(results)
+}
+
+func (o *OpenRouter) formatTools(defs []ToolDef) []map[string]interface{} {
+	var out []map[string]interface{}
+	for _, d := range defs {
+		out = append(out, map[string]interface{}{
+			"type": "function",
+			"function": map[string]interface{}{
+				"name":        d.Name,
+				"description": d.Description,
+				"parameters":  json.RawMessage(d.Schema),
+			},
+		})
+	}
+	return out
+}
+
+var _ = strings.Contains

--- a/llm/provider.go
+++ b/llm/provider.go
@@ -61,6 +61,27 @@ type ToolDef struct {
 
 // Resolve maps a model name to the correct provider using the given config.
 func Resolve(name string, pc config.ProviderConfig) (Provider, error) {
+	if name == "" {
+		return nil, fmt.Errorf("model name required")
+	}
+	if strings.HasPrefix(name, "openrouter:") {
+		if pc.OpenRouterKey == "" {
+			return nil, fmt.Errorf("OPENROUTER_API_KEY not configured")
+		}
+		return NewOpenRouter(pc.OpenRouterKey, "", strings.TrimPrefix(name, "openrouter:")), nil
+	}
+	if strings.HasPrefix(name, "openai:") {
+		if pc.OpenAIKey == "" {
+			return nil, fmt.Errorf("OPENAI_API_KEY not configured")
+		}
+		return NewOpenAI(pc.OpenAIKey, "", strings.TrimPrefix(name, "openai:")), nil
+	}
+	if strings.HasPrefix(name, "anthropic:") {
+		if pc.AnthropicKey == "" {
+			return nil, fmt.Errorf("ANTHROPIC_API_KEY not configured")
+		}
+		return NewAnthropic(pc.AnthropicKey, "", strings.TrimPrefix(name, "anthropic:")), nil
+	}
 	switch {
 	case strings.HasPrefix(name, "gpt-") || strings.HasPrefix(name, "o1-") || strings.HasPrefix(name, "o3-") || strings.HasPrefix(name, "o4-"):
 		if pc.OpenAIKey == "" {
@@ -72,12 +93,14 @@ func Resolve(name string, pc config.ProviderConfig) (Provider, error) {
 			return nil, fmt.Errorf("ANTHROPIC_API_KEY not configured")
 		}
 		return NewAnthropic(pc.AnthropicKey, "", name), nil
+	case strings.HasPrefix(name, "kimi-") || strings.HasPrefix(name, "moonshot-"):
+		if pc.OpenRouterKey == "" {
+			return nil, fmt.Errorf("OPENROUTER_API_KEY not configured")
+		}
+		return NewOpenRouter(pc.OpenRouterKey, "", name), nil
 	default:
 		if pc.OllamaURL != "" {
 			return NewOpenAI("", pc.OllamaURL, name), nil
-		}
-		if pc.OpenAIKey != "" {
-			return NewOpenAI(pc.OpenAIKey, "", name), nil
 		}
 		return nil, fmt.Errorf("unknown model: %s", name)
 	}

--- a/llm/provider.go
+++ b/llm/provider.go
@@ -64,6 +64,12 @@ func Resolve(name string, pc config.ProviderConfig) (Provider, error) {
 	if name == "" {
 		return nil, fmt.Errorf("model name required")
 	}
+	if strings.HasPrefix(name, "ollama:") {
+		if pc.OllamaURL == "" {
+			return nil, fmt.Errorf("OLLAMA_MODEL not configured")
+		}
+		return NewOpenAI("", pc.OllamaURL, strings.TrimPrefix(name, "ollama:")), nil
+	}
 	if strings.HasPrefix(name, "openrouter:") {
 		if pc.OpenRouterKey == "" {
 			return nil, fmt.Errorf("OPENROUTER_API_KEY not configured")
@@ -82,18 +88,23 @@ func Resolve(name string, pc config.ProviderConfig) (Provider, error) {
 		}
 		return NewAnthropic(pc.AnthropicKey, "", strings.TrimPrefix(name, "anthropic:")), nil
 	}
-	switch {
-	case strings.HasPrefix(name, "gpt-") || strings.HasPrefix(name, "o1-") || strings.HasPrefix(name, "o3-") || strings.HasPrefix(name, "o4-"):
+	switch strings.ToLower(pc.DefaultProvider) {
+	case "ollama":
+		if pc.OllamaURL == "" {
+			return nil, fmt.Errorf("OLLAMA_MODEL not configured")
+		}
+		return NewOpenAI("", pc.OllamaURL, name), nil
+	case "openai":
 		if pc.OpenAIKey == "" {
 			return nil, fmt.Errorf("OPENAI_API_KEY not configured")
 		}
 		return NewOpenAI(pc.OpenAIKey, "", name), nil
-	case strings.HasPrefix(name, "claude-"):
+	case "anthropic":
 		if pc.AnthropicKey == "" {
 			return nil, fmt.Errorf("ANTHROPIC_API_KEY not configured")
 		}
 		return NewAnthropic(pc.AnthropicKey, "", name), nil
-	case strings.HasPrefix(name, "kimi-") || strings.HasPrefix(name, "moonshot-"):
+	case "openrouter":
 		if pc.OpenRouterKey == "" {
 			return nil, fmt.Errorf("OPENROUTER_API_KEY not configured")
 		}

--- a/llm/provider.go
+++ b/llm/provider.go
@@ -102,6 +102,15 @@ func Resolve(name string, pc config.ProviderConfig) (Provider, error) {
 		if pc.OllamaURL != "" {
 			return NewOpenAI("", pc.OllamaURL, name), nil
 		}
+		if pc.OpenRouterKey != "" {
+			return NewOpenRouter(pc.OpenRouterKey, "", name), nil
+		}
+		if pc.OpenAIKey != "" {
+			return NewOpenAI(pc.OpenAIKey, "", name), nil
+		}
+		if pc.AnthropicKey != "" {
+			return NewAnthropic(pc.AnthropicKey, "", name), nil
+		}
 		return nil, fmt.Errorf("unknown model: %s", name)
 	}
 }


### PR DESCRIPTION
- Add OpenRouter API key wiring to config
- Add OpenRouter provider support in model resolve
- Add `DEFAULT_PROVIDER` for clean no-prefix DX
- Add exact provider prefixes:
  - `openrouter:`
  - `openai:`
  - `anthropic:`
  - `ollama:`
- Update setup flow to prompt for default provider
- Update README with provider docs and routing rules
- Update ROADMAP with completed provider wiring items

Notes:
- No silent provider guessing once `DEFAULT_PROVIDER` set
- Legacy fallback still works when `DEFAULT_PROVIDER` empty