### PR TITLE
feat: image support

### DIFF
--- a/NEVINHO.md
+++ b/NEVINHO.md
@@ -42,6 +42,12 @@ All work as both Discord slash commands (`/x`) and plain text in DMs.
 
 The user can send Discord voice messages. The bot transcribes them locally with whisper.cpp (no API, no cost) and feeds the text into your turn just like a typed message. From your side it looks like normal text input.
 
+## Image input
+
+The user can attach images to a Discord message. JPEG, PNG, GIF, and WebP are accepted, capped at 5MB each, up to 4 per message. They arrive in your turn as inline image content alongside any text or transcribed voice. You can describe, read, compare, or reason about them directly. No tool call needed.
+
+Image input requires a vision capable model (any Claude 4.x, GPT-4o family, or an Ollama model whose name contains llava, vision, qwen2-vl, bakllava, or moondream). On non-vision models the bot rejects the message before it reaches you.
+
 ## Safety and approval
 
 Some actions need explicit user approval before they run:

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ Send voice messages in Discord and nevinho transcribes them using a local Whispe
 
 Enable during `nevinho setup`. Requires `ffmpeg` and a C compiler (auto-installed if missing). The Whisper model (~75MB) is stored in `~/.nevinho/whisper/`.
 
+## Images
+
+Attach images to a Discord message and nevinho passes them straight to a vision capable model. JPEG, PNG, GIF, WebP. Up to 4 images per message, 5MB each. Works with any Claude 4.x model, the GPT-4o family, and Ollama vision models like llava or llama3.2-vision.
+
+If the current model can't read images, nevinho replies with a hint to switch via `/model` instead of dropping the message silently.
+
 ## Commands
 
 | Command             | What it does                              |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -113,7 +113,6 @@ Real but deferred. Ship when the above is solid or when a user hits the pain.
 - [ ] Memory relevance ranking. Rank entries against the current message, inject top-K only.
 - [ ] Memory auto-expiry. `last_used` timestamp. Stale entries drop out.
 - [ ] Web tooling polish. URL cache (LRU, 5 min TTL). PDF extraction. Search result dedup.
-- [ ] Image and attachment support. Route Discord images to vision-capable models.
 - [ ] WhatsApp transport via `whatsmeow`. Needs a `transport/` interface refactor and real user demand first.
 - [ ] Proactive heartbeat. Periodic checklist drives agent actions. Ship only if distinct from scheduled tasks.
 - [ ] `delegate_research` tool. Fresh context, runs a research task, returns a summary. Only if long research chains blow the main context.
@@ -139,3 +138,4 @@ Real but deferred. Ship when the above is solid or when a user hits the pain.
 - [x] **Web tooling.** Tavily advanced search and extract. Jina Reader fallback. Polite headers. Explicit error signaling. 429/5xx retries.
 - [x] **Conversation persistence (ELEPHANT).** On shutdown, summarize each user's history to `~/.nevinho/summaries/{userID}.md`. Reload as `[Previous conversation: ...]` preamble on next start. Default on, toggle via `ELEPHANT=off`. `/forget` wipes both in-memory history and the saved summary.
 - [x] **Self-knowledge.** `NEVINHO.md` at repo root, embedded in the binary via `go:embed` and auto-injected into the system prompt. Covers identity, persistence model, commands, architecture, and source-lookup strategy (local file_read for dev installs, web_read against GitHub raw for binary installs). `/memory` and `/summary` expose persisted state to the user.
+- [x] **Image input.** Discord image attachments (JPEG/PNG/GIF/WebP) routed inline to vision-capable models. 5MB per image, 4 per message. Vision capability checked per model before send. Anthropic and OpenAI both supported.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -129,7 +129,7 @@ func (a *Agent) Cancel(userID string) bool {
 	return false
 }
 
-func (a *Agent) Chat(userID, text string, isVoice bool) (string, error) {
+func (a *Agent) Chat(userID, text string, isVoice bool, images []llm.Image) (string, error) {
 	lock := a.getUserLock(userID)
 	lock.Lock()
 	defer lock.Unlock()
@@ -200,7 +200,7 @@ func (a *Agent) Chat(userID, text string, isVoice bool) (string, error) {
 
 	a.maybeLoadSummary(userID)
 
-	if evicted := a.appendHistory(userID, a.llm.FormatUserMessage(text)); len(evicted) > 2 {
+	if evicted := a.appendHistory(userID, a.llm.FormatUserMessageWithImages(text, images)); len(evicted) > 2 {
 		a.summarizeAndPrepend(userID, evicted)
 	}
 

--- a/discord/bot.go
+++ b/discord/bot.go
@@ -13,8 +13,14 @@ import (
 	"github.com/bwmarrin/discordgo"
 	"github.com/lucasnevespereira/nevinho/agent"
 	"github.com/lucasnevespereira/nevinho/config"
+	"github.com/lucasnevespereira/nevinho/llm"
 	"github.com/lucasnevespereira/nevinho/logger"
 	"github.com/lucasnevespereira/nevinho/voice"
+)
+
+const (
+	maxImageBytes  = 5 * 1024 * 1024
+	maxImagesPerMessage = 4
 )
 
 const maxMessageLen = 2000
@@ -266,7 +272,7 @@ func (b *Bot) onMessage(s *discordgo.Session, m *discordgo.MessageCreate) {
 	isVoice := false
 	voiceMessageID := ""
 
-	// Handle voice messages: transcribe audio attachments
+	// Voice messages. Transcribe audio attachments when there is no text.
 	if text == "" && len(m.Attachments) > 0 {
 		for _, att := range m.Attachments {
 			if isAudioAttachment(att) {
@@ -284,7 +290,37 @@ func (b *Bot) onMessage(s *discordgo.Session, m *discordgo.MessageCreate) {
 		}
 	}
 
-	if text == "" {
+	// Image attachments. Independent of voice path. The model sees images
+	// alongside any text or voice transcription in the same turn.
+	var images []llm.Image
+	for _, att := range m.Attachments {
+		mt := imageMediaType(att)
+		if mt == "" {
+			continue
+		}
+		if len(images) >= maxImagesPerMessage {
+			s.ChannelMessageSend(m.ChannelID, fmt.Sprintf("Only the first %d images were used.", maxImagesPerMessage))
+			break
+		}
+		if att.Size > maxImageBytes {
+			s.ChannelMessageSend(m.ChannelID, fmt.Sprintf("Skipped %s (over 5MB).", att.Filename))
+			continue
+		}
+		img, err := b.downloadImage(att, mt)
+		if err != nil {
+			logger.Err(fmt.Errorf("image %s: %w", att.Filename, err))
+			s.ChannelMessageSend(m.ChannelID, fmt.Sprintf("Failed to load %s.", att.Filename))
+			continue
+		}
+		images = append(images, img)
+	}
+
+	if text == "" && len(images) == 0 {
+		return
+	}
+
+	if len(images) > 0 && !llm.ModelSupportsVision(b.agent.Model()) {
+		s.ChannelMessageSend(m.ChannelID, fmt.Sprintf("Current model `%s` cannot read images. Switch to a vision capable model with `/model`.", b.agent.Model()))
 		return
 	}
 
@@ -372,7 +408,7 @@ func (b *Bot) onMessage(s *discordgo.Session, m *discordgo.MessageCreate) {
 	indicator := newActivityIndicator(s, m.ChannelID)
 	b.agent.SetToolCallback(m.Author.ID, indicator.onEvent)
 
-	response, err := b.agent.Chat(m.Author.ID, text, isVoice)
+	response, err := b.agent.Chat(m.Author.ID, text, isVoice, images)
 	b.agent.SetToolCallback(m.Author.ID, nil)
 	indicator.Close()
 	stopTyping()
@@ -750,7 +786,7 @@ func (b *Bot) runApproval(s *discordgo.Session, channelID, userID string) {
 	indicator := newActivityIndicator(s, channelID)
 	b.agent.SetToolCallback(userID, indicator.onEvent)
 
-	response, err := b.agent.Chat(userID, "yes", false)
+	response, err := b.agent.Chat(userID, "yes", false, nil)
 	b.agent.SetToolCallback(userID, nil)
 	indicator.Close()
 	stopTyping()
@@ -854,6 +890,49 @@ func isAudioAttachment(att *discordgo.MessageAttachment) bool {
 	}
 	ext := strings.ToLower(filepath.Ext(att.Filename))
 	return audioExtensions[ext]
+}
+
+var imageMediaTypes = map[string]bool{
+	"image/jpeg": true,
+	"image/png":  true,
+	"image/gif":  true,
+	"image/webp": true,
+}
+
+var imageExtMediaTypes = map[string]string{
+	".jpg":  "image/jpeg",
+	".jpeg": "image/jpeg",
+	".png":  "image/png",
+	".gif":  "image/gif",
+	".webp": "image/webp",
+}
+
+// imageMediaType returns the canonical media type for a Discord attachment, or
+// empty string if it is not a supported image. Falls back on the filename
+// extension when ContentType is missing or generic.
+func imageMediaType(att *discordgo.MessageAttachment) string {
+	if imageMediaTypes[att.ContentType] {
+		return att.ContentType
+	}
+	ext := strings.ToLower(filepath.Ext(att.Filename))
+	return imageExtMediaTypes[ext]
+}
+
+func (b *Bot) downloadImage(att *discordgo.MessageAttachment, mediaType string) (llm.Image, error) {
+	resp, err := http.Get(att.URL)
+	if err != nil {
+		return llm.Image{}, fmt.Errorf("download: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxImageBytes+1))
+	if err != nil {
+		return llm.Image{}, fmt.Errorf("read: %w", err)
+	}
+	if len(data) > maxImageBytes {
+		return llm.Image{}, fmt.Errorf("image exceeds %d bytes", maxImageBytes)
+	}
+	return llm.Image{MediaType: mediaType, Data: data}, nil
 }
 
 func (b *Bot) transcribeAttachment(s *discordgo.Session, channelID string, att *discordgo.MessageAttachment) string {

--- a/discord/image_test.go
+++ b/discord/image_test.go
@@ -1,0 +1,39 @@
+package discord
+
+import (
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func TestImageMediaType(t *testing.T) {
+	cases := []struct {
+		name        string
+		contentType string
+		filename    string
+		want        string
+	}{
+		{"png by content type", "image/png", "shot.png", "image/png"},
+		{"jpeg by content type", "image/jpeg", "x.jpg", "image/jpeg"},
+		{"gif by content type", "image/gif", "x.gif", "image/gif"},
+		{"webp by content type", "image/webp", "x.webp", "image/webp"},
+		{"png by extension when content empty", "", "screenshot.PNG", "image/png"},
+		{"jpeg by extension jpg", "", "photo.jpg", "image/jpeg"},
+		{"jpeg by extension jpeg", "", "photo.jpeg", "image/jpeg"},
+		{"unsupported type", "image/heic", "live.heic", ""},
+		{"text file", "text/plain", "notes.txt", ""},
+		{"audio not image", "audio/ogg", "v.ogg", ""},
+		{"empty", "", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			att := &discordgo.MessageAttachment{
+				ContentType: c.contentType,
+				Filename:    c.filename,
+			}
+			if got := imageMediaType(att); got != c.want {
+				t.Errorf("imageMediaType(%q, %q) = %q, want %q", c.contentType, c.filename, got, c.want)
+			}
+		})
+	}
+}

--- a/llm/anthropic.go
+++ b/llm/anthropic.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -109,6 +110,28 @@ func (a *Anthropic) Complete(ctx context.Context, req *Request) (*Response, erro
 
 func (a *Anthropic) FormatUserMessage(text string) json.RawMessage {
 	msg, _ := json.Marshal(map[string]interface{}{"role": "user", "content": text})
+	return msg
+}
+
+func (a *Anthropic) FormatUserMessageWithImages(text string, images []Image) json.RawMessage {
+	if len(images) == 0 {
+		return a.FormatUserMessage(text)
+	}
+	var content []map[string]interface{}
+	if text != "" {
+		content = append(content, map[string]interface{}{"type": "text", "text": text})
+	}
+	for _, img := range images {
+		content = append(content, map[string]interface{}{
+			"type": "image",
+			"source": map[string]string{
+				"type":       "base64",
+				"media_type": img.MediaType,
+				"data":       base64.StdEncoding.EncodeToString(img.Data),
+			},
+		})
+	}
+	msg, _ := json.Marshal(map[string]interface{}{"role": "user", "content": content})
 	return msg
 }
 

--- a/llm/format_test.go
+++ b/llm/format_test.go
@@ -1,0 +1,136 @@
+package llm
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestAnthropicFormatUserMessageWithImages(t *testing.T) {
+	a := NewAnthropic("k", "", "claude-haiku-4-5")
+	img := Image{MediaType: "image/png", Data: []byte("PNG\x00bytes")}
+	raw := a.FormatUserMessageWithImages("hello", []Image{img})
+
+	var msg struct {
+		Role    string                   `json:"role"`
+		Content []map[string]interface{} `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.Role != "user" {
+		t.Errorf("role = %q, want user", msg.Role)
+	}
+	if len(msg.Content) != 2 {
+		t.Fatalf("got %d blocks, want 2", len(msg.Content))
+	}
+	if msg.Content[0]["type"] != "text" || msg.Content[0]["text"] != "hello" {
+		t.Errorf("first block bad: %+v", msg.Content[0])
+	}
+	if msg.Content[1]["type"] != "image" {
+		t.Errorf("second block type = %v, want image", msg.Content[1]["type"])
+	}
+	src, ok := msg.Content[1]["source"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("source not a map: %T", msg.Content[1]["source"])
+	}
+	if src["type"] != "base64" || src["media_type"] != "image/png" {
+		t.Errorf("source bad: %+v", src)
+	}
+	data, _ := src["data"].(string)
+	if data == "" || strings.Contains(data, "\x00") {
+		t.Errorf("data not base64 encoded: %q", data)
+	}
+}
+
+func TestAnthropicFormatUserMessageWithImagesEmptyText(t *testing.T) {
+	a := NewAnthropic("k", "", "claude-haiku-4-5")
+	img := Image{MediaType: "image/jpeg", Data: []byte("JPG")}
+	raw := a.FormatUserMessageWithImages("", []Image{img})
+
+	var msg struct {
+		Content []map[string]interface{} `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(msg.Content) != 1 {
+		t.Fatalf("got %d blocks, want 1 (image only)", len(msg.Content))
+	}
+	if msg.Content[0]["type"] != "image" {
+		t.Errorf("only block type = %v, want image", msg.Content[0]["type"])
+	}
+}
+
+func TestAnthropicFormatUserMessageWithImagesNoImagesIsString(t *testing.T) {
+	a := NewAnthropic("k", "", "claude-haiku-4-5")
+	raw := a.FormatUserMessageWithImages("plain", nil)
+
+	var msg struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	var s string
+	if err := json.Unmarshal(msg.Content, &s); err != nil {
+		t.Fatalf("content not a string when images empty: %s", msg.Content)
+	}
+	if s != "plain" {
+		t.Errorf("content = %q, want plain", s)
+	}
+}
+
+func TestOpenAIFormatUserMessageWithImages(t *testing.T) {
+	o := NewOpenAI("k", "", "gpt-4o-mini")
+	img := Image{MediaType: "image/png", Data: []byte("PNG\x00bytes")}
+	raw := o.FormatUserMessageWithImages("look", []Image{img})
+
+	var msg struct {
+		Role    string                   `json:"role"`
+		Content []map[string]interface{} `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.Role != "user" {
+		t.Errorf("role = %q, want user", msg.Role)
+	}
+	if len(msg.Content) != 2 {
+		t.Fatalf("got %d blocks, want 2", len(msg.Content))
+	}
+	if msg.Content[0]["type"] != "text" || msg.Content[0]["text"] != "look" {
+		t.Errorf("first block bad: %+v", msg.Content[0])
+	}
+	if msg.Content[1]["type"] != "image_url" {
+		t.Errorf("second block type = %v, want image_url", msg.Content[1]["type"])
+	}
+	imgURL, ok := msg.Content[1]["image_url"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("image_url not a map: %T", msg.Content[1]["image_url"])
+	}
+	url, _ := imgURL["url"].(string)
+	if !strings.HasPrefix(url, "data:image/png;base64,") {
+		t.Errorf("url = %q, want data: prefix", url)
+	}
+}
+
+func TestOpenAIFormatUserMessageWithImagesNoImagesIsString(t *testing.T) {
+	o := NewOpenAI("k", "", "gpt-4o-mini")
+	raw := o.FormatUserMessageWithImages("plain", nil)
+
+	var msg struct {
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	var s string
+	if err := json.Unmarshal(msg.Content, &s); err != nil {
+		t.Fatalf("content not a string when images empty: %s", msg.Content)
+	}
+	if s != "plain" {
+		t.Errorf("content = %q, want plain", s)
+	}
+}

--- a/llm/image.go
+++ b/llm/image.go
@@ -1,0 +1,30 @@
+package llm
+
+import "strings"
+
+// Image is a single image attachment routed to a vision capable model.
+// Data holds raw bytes. Providers encode as needed for their wire format.
+type Image struct {
+	MediaType string
+	Data      []byte
+}
+
+// ModelSupportsVision reports whether the given model accepts image input.
+// Conservative. Returns true only for known good model families.
+func ModelSupportsVision(name string) bool {
+	switch {
+	case strings.HasPrefix(name, "claude"):
+		return true
+	case strings.HasPrefix(name, "gpt-4o"):
+		return true
+	case strings.HasPrefix(name, "gpt-4-turbo"), strings.HasPrefix(name, "gpt-4-vision"):
+		return true
+	}
+	lower := strings.ToLower(name)
+	for _, marker := range []string{"llava", "vision", "qwen2-vl", "bakllava", "moondream"} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/llm/image_test.go
+++ b/llm/image_test.go
@@ -1,0 +1,32 @@
+package llm
+
+import "testing"
+
+func TestModelSupportsVision(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"claude-haiku-4-5-20251001", true},
+		{"claude-sonnet-4-6", true},
+		{"claude-opus-4-7", true},
+		{"gpt-4o", true},
+		{"gpt-4o-mini", true},
+		{"gpt-4-turbo", true},
+		{"gpt-3.5-turbo", false},
+		{"o3-mini", false},
+		{"llava:7b", true},
+		{"llama3.2-vision", true},
+		{"qwen2-vl:7b", true},
+		{"bakllava", true},
+		{"moondream", true},
+		{"llama3", false},
+		{"codellama", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := ModelSupportsVision(c.name); got != c.want {
+			t.Errorf("ModelSupportsVision(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/llm/openai.go
+++ b/llm/openai.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 )
@@ -92,6 +93,25 @@ func (o *OpenAI) Complete(ctx context.Context, req *Request) (*Response, error) 
 
 func (o *OpenAI) FormatUserMessage(text string) json.RawMessage {
 	msg, _ := json.Marshal(map[string]interface{}{"role": "user", "content": text})
+	return msg
+}
+
+func (o *OpenAI) FormatUserMessageWithImages(text string, images []Image) json.RawMessage {
+	if len(images) == 0 {
+		return o.FormatUserMessage(text)
+	}
+	var content []map[string]interface{}
+	if text != "" {
+		content = append(content, map[string]interface{}{"type": "text", "text": text})
+	}
+	for _, img := range images {
+		dataURL := "data:" + img.MediaType + ";base64," + base64.StdEncoding.EncodeToString(img.Data)
+		content = append(content, map[string]interface{}{
+			"type":      "image_url",
+			"image_url": map[string]string{"url": dataURL},
+		})
+	}
+	msg, _ := json.Marshal(map[string]interface{}{"role": "user", "content": content})
 	return msg
 }
 

--- a/llm/provider.go
+++ b/llm/provider.go
@@ -12,9 +12,12 @@ import (
 type Provider interface {
 	Complete(ctx context.Context, req *Request) (*Response, error)
 	FormatUserMessage(text string) json.RawMessage
+	// FormatUserMessageWithImages emits a user message carrying inline images.
+	// When images is empty the result is equivalent to FormatUserMessage.
+	FormatUserMessageWithImages(text string, images []Image) json.RawMessage
 	FormatToolResults(results []ToolResult) []json.RawMessage
 	// ReplaceToolResult swaps the stored output of a prior tool_result for the
-	// given tool-use id. Used after deferred approval so the LLM sees the
+	// given tool use id. Used after deferred approval so the LLM sees the
 	// actual executed output instead of the stale NEEDS_APPROVAL placeholder.
 	ReplaceToolResult(history []json.RawMessage, toolUseID, newOutput string) []json.RawMessage
 	Model() string


### PR DESCRIPTION
## What

Users can now attach images to Discord messages. Nevinho accepts JPEG, PNG, GIF, and WebP attachments (up to 4 per message, 5MB each) and routes them directly to vision-capable models for analysis. The bot validates that the current model supports images before accepting attachments and provides a helpful hint to switch models if needed.

## Changes

- Image struct and ModelSupportsVision helper to detect vision-capable models (Claude 4.x, GPT-4o, Ollama llava/qwen2-vl/bakllava/moondream variants)
- Discord bot extracts image attachments, validates size and format, downloads and encodes them
- Agent.Chat signature expanded to accept optional image slice
- FormatUserMessageWithImages methods in Anthropic and OpenAI providers to inline images in the message content alongside text
- Image media type detection via content-type header with fallback to filename extension
- Rejection of images on non-vision models with actionable error message prompting `/model` switch
- Tests covering image media type detection and message formatting for both providers