### PR TITLE
feat(safeio): atomic, mode preserving writes for persisted state

### DIFF
--- a/agent/persistence.go
+++ b/agent/persistence.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/lucasnevespereira/nevinho/safeio"
 )
 
 const (
@@ -47,8 +49,8 @@ func loadSummary(configDir, userID string) string {
 	return strings.TrimSpace(string(data))
 }
 
-// saveSummary writes the summary atomically: write to .tmp then rename so a
-// crash mid-write can't leave a half-written file.
+// saveSummary writes the summary atomically through safeio.WriteFile so a
+// crash mid write cannot leave a half written file.
 func saveSummary(configDir, userID, text string) error {
 	path, err := summaryPath(configDir, userID)
 	if err != nil {
@@ -61,18 +63,8 @@ func saveSummary(configDir, userID, text string) error {
 	if len(text) > summaryMaxSize {
 		text = text[:summaryMaxSize]
 	}
-
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return fmt.Errorf("create summaries dir: %w", err)
-	}
-
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, []byte(text+"\n"), 0644); err != nil {
+	if err := safeio.WriteFile(path, []byte(text+"\n"), 0o644); err != nil {
 		return fmt.Errorf("write summary: %w", err)
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		os.Remove(tmp)
-		return fmt.Errorf("rename summary: %w", err)
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/lucasnevespereira/nevinho/crypto"
+	"github.com/lucasnevespereira/nevinho/safeio"
 )
 
 type Config struct {
@@ -86,15 +87,11 @@ func (c *Config) Save() error {
 		return err
 	}
 
-	if err := os.MkdirAll(c.dir, 0755); err != nil {
-		return err
-	}
-
 	enc, err := crypto.Encrypt(c.key, plain)
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(c.filePath, enc, 0600)
+	return safeio.WriteFile(c.filePath, enc, 0o600)
 }
 
 func (c *Config) Get(key string) (string, error) {

--- a/memory/memory.go
+++ b/memory/memory.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/lucasnevespereira/nevinho/safeio"
 )
 
 const (
@@ -49,7 +51,7 @@ func Add(configDir, entry string) error {
 		lines = lines[len(lines)-maxEntries:]
 	}
 
-	return os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0644)
+	return safeio.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644)
 }
 
 // correction patterns that indicate user preferences

--- a/safeio/safeio.go
+++ b/safeio/safeio.go
@@ -1,0 +1,61 @@
+// Package safeio provides atomic, crash safe file writes.
+//
+// On a long running VPS process, a kill signal or kernel panic mid write
+// can leave a half written file behind. WriteFile streams to a sibling
+// temp file, fsyncs, then renames over the destination. POSIX guarantees
+// the rename is atomic, so a reader after a crash sees either the old
+// file or the new one. Never an empty or truncated mix.
+package safeio
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// WriteFile writes data to path atomically.
+//
+// If the destination already exists, its file mode is preserved.
+// Otherwise perm is used. The parent directory is created if missing.
+func WriteFile(path string, data []byte, perm fs.FileMode) error {
+	mode := perm
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".write.*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("fsync temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Chmod(tmpPath, mode); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("chmod temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("rename temp: %w", err)
+	}
+	return nil
+}

--- a/safeio/safeio_test.go
+++ b/safeio/safeio_test.go
@@ -1,0 +1,96 @@
+package safeio
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteFileCreates(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "new.txt")
+
+	if err := WriteFile(path, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("content = %q, want hello", got)
+	}
+
+	info, _ := os.Stat(path)
+	if info.Mode().Perm() != 0o644 {
+		t.Errorf("mode = %v, want 0644", info.Mode().Perm())
+	}
+}
+
+func TestWriteFilePreservesMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.txt")
+
+	if err := os.WriteFile(path, []byte("orig"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WriteFile(path, []byte("new"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	info, _ := os.Stat(path)
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("mode = %v, want 0600 (preserved)", info.Mode().Perm())
+	}
+}
+
+func TestWriteFilePreservesExecBit(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "run.sh")
+
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WriteFile(path, []byte("#!/bin/sh\necho hi\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	info, _ := os.Stat(path)
+	if info.Mode().Perm() != 0o755 {
+		t.Errorf("mode = %v, want 0755 (preserved)", info.Mode().Perm())
+	}
+}
+
+func TestWriteFileCreatesParentDir(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "deep", "file.txt")
+
+	if err := WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("file missing: %v", err)
+	}
+}
+
+func TestWriteFileNoTempLeftOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ok.txt")
+
+	if err := WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		name := e.Name()
+		if name == "ok.txt" {
+			continue
+		}
+		t.Errorf("leftover file in dir: %s", name)
+	}
+}

--- a/tools/file.go
+++ b/tools/file.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/lucasnevespereira/nevinho/safeio"
 )
 
 const (
@@ -110,7 +112,7 @@ func (r *Registry) fileWrite(input json.RawMessage, userID string) string {
 		return fmt.Sprintf("failed to create directory: %v", err)
 	}
 
-	if err := os.WriteFile(resolved, []byte(in.Content), 0644); err != nil {
+	if err := safeio.WriteFile(resolved, []byte(in.Content), 0o644); err != nil {
 		return fmt.Sprintf("failed to write: %v", err)
 	}
 
@@ -233,6 +235,10 @@ func (r *Registry) fileEdit(input json.RawMessage, userID string) string {
 		return fmt.Sprintf("failed to read: %v", err)
 	}
 
+	if len(data) > maxFileSize {
+		return fmt.Sprintf("file too large to edit (%dKB, max %dKB). Use file_write or split the change.", len(data)/1024, maxFileSize/1024)
+	}
+
 	raw := string(data)
 	content, hasBOM := stripBOM(raw)
 	content, hasCRLF := normalizeLineEndings(content)
@@ -292,7 +298,7 @@ func (r *Registry) fileEdit(input json.RawMessage, userID string) string {
 		newContent = utf8BOM + newContent
 	}
 
-	if err := os.WriteFile(resolved, []byte(newContent), 0644); err != nil {
+	if err := safeio.WriteFile(resolved, []byte(newContent), 0o644); err != nil {
 		return fmt.Sprintf("failed to write: %v", err)
 	}
 

--- a/tools/file_test.go
+++ b/tools/file_test.go
@@ -360,6 +360,50 @@ func TestFileEditCRLF(t *testing.T) {
 	}
 }
 
+func TestFileEditPreservesMode(t *testing.T) {
+	r, dir := newTestRegistry(t)
+	path := filepath.Join(dir, "run.sh")
+
+	if err := os.WriteFile(path, []byte("#!/bin/sh\necho hi\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	input := marshalInput(t, map[string]string{
+		"path":     path,
+		"old_text": "echo hi",
+		"new_text": "echo bye",
+	})
+	got := r.fileEdit(input, "u1")
+	if !strings.Contains(got, "edited") {
+		t.Fatalf("expected success, got: %s", got)
+	}
+
+	info, _ := os.Stat(path)
+	if info.Mode().Perm() != 0o755 {
+		t.Errorf("mode = %v, want 0755 (preserved)", info.Mode().Perm())
+	}
+}
+
+func TestFileEditRejectsOversizeFile(t *testing.T) {
+	r, dir := newTestRegistry(t)
+	path := filepath.Join(dir, "huge.txt")
+
+	big := strings.Repeat("x", maxFileSize+1)
+	if err := os.WriteFile(path, []byte(big), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	input := marshalInput(t, map[string]string{
+		"path":     path,
+		"old_text": "x",
+		"new_text": "y",
+	})
+	got := r.fileEdit(input, "u1")
+	if !strings.Contains(got, "too large") {
+		t.Errorf("expected size cap error, got: %s", got)
+	}
+}
+
 func TestFormatSize(t *testing.T) {
 	tests := []struct {
 		bytes int64

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/lucasnevespereira/nevinho/config"
 	"github.com/lucasnevespereira/nevinho/llm"
+	"github.com/lucasnevespereira/nevinho/safeio"
 )
 
 const maxResponseLen = 8000
@@ -348,11 +349,7 @@ func (r *Registry) saveApproved() {
 		log.Printf("failed to marshal approved paths: %v", err)
 		return
 	}
-	if err := os.MkdirAll(filepath.Dir(r.permFile), 0755); err != nil {
-		log.Printf("failed to create config dir: %v", err)
-		return
-	}
-	if err := os.WriteFile(r.permFile, data, 0644); err != nil {
+	if err := safeio.WriteFile(r.permFile, data, 0o644); err != nil {
 		log.Printf("failed to save approved paths: %v", err)
 	}
 }


### PR DESCRIPTION
## What
Introduce atomic, crash-safe file writes across the codebase through a new `safeio` package. All persisted state (config, summaries, memory, user file writes) now use atomic writes with fsync, preventing half-written files from crashes or kill signals. File permissions are preserved on updates, so secrets stay 0o600 and scripts stay executable.

## Changes
- Add `safeio` package with `WriteFile` that streams to temp, fsyncs, then atomically renames
- Preserve existing file permissions when updating; use provided mode only for new files
- Auto-create parent directories in `safeio.WriteFile`
- Migrate all `os.WriteFile` calls to `safeio.WriteFile` across agent, config, memory, tools, and registry packages
- Add validation in `fileEdit` to reject files larger than `maxFileSize` before attempting edits
- Add tests for atomic writes, mode preservation, exec bit preservation, parent dir creation, and cleanup