### PR TITLE
fix: restore intents, prevent duplicate instances, fix summarize hang

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	maxOutputTokens        = 4096
+	maxOutputTokens  = 4096
 	maxLoops         = 25
 	maxHistoryTokens = 30_000
 	maxToolResult    = 4000
@@ -65,15 +65,15 @@ type Agent struct {
 	version string
 	selfDoc string
 
-	mu             sync.Mutex
-	history        map[string][]json.RawMessage
-	userLock       map[string]*sync.Mutex
-	cancelFn       map[string]context.CancelFunc
-	toolCb         map[string]ToolCallback
-	pendingToolID  map[string]string
-	startTime time.Time
-	tokensIn  int
-	tokensOut int
+	mu            sync.Mutex
+	history       map[string][]json.RawMessage
+	userLock      map[string]*sync.Mutex
+	cancelFn      map[string]context.CancelFunc
+	toolCb        map[string]ToolCallback
+	pendingToolID map[string]string
+	startTime     time.Time
+	tokensIn      int
+	tokensOut     int
 }
 
 func New(provider llm.Provider, cfg *config.Config, version, selfDoc string) *Agent {
@@ -598,7 +598,9 @@ func (a *Agent) summarizeAndPrepend(userID string, evicted []json.RawMessage) {
 	if flat == "" {
 		return
 	}
-	resp, err := a.llm.Complete(context.Background(), &llm.Request{
+	summarizeCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	resp, err := a.llm.Complete(summarizeCtx, &llm.Request{
 		SystemPrompt: "Summarize this conversation excerpt in 2-3 sentences. Focus on what was asked, what was done, and important outcomes.",
 		Messages:     []json.RawMessage{a.llm.FormatUserMessage(flat, nil)},
 		MaxTokens:    200,

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -2,9 +2,13 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -19,6 +23,8 @@ import (
 // macOS it runs in the foreground when the user calls `nevinho start`.
 func Serve(configDir, version, selfDoc string) {
 	logger.Init()
+
+	checkPID(configDir)
 
 	cfg, err := config.Load(configDir)
 	if err != nil {
@@ -44,6 +50,8 @@ func Serve(configDir, version, selfDoc string) {
 		log.Fatalf("failed to start bot: %v", err)
 	}
 
+	writePID(configDir)
+
 	logger.Info("nevinho is online")
 
 	stop := make(chan os.Signal, 1)
@@ -52,11 +60,39 @@ func Serve(configDir, version, selfDoc string) {
 
 	logger.Info("shutting down...")
 
+	os.Remove(pidPath(configDir))
+
 	persistCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	a.PersistAll(persistCtx)
 	cancel()
 
 	bot.Stop()
+}
+
+func pidPath(configDir string) string {
+	return filepath.Join(configDir, "nevinho.pid")
+}
+
+func checkPID(configDir string) {
+	data, err := os.ReadFile(pidPath(configDir))
+	if err != nil {
+		return
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return
+	}
+	if proc.Signal(syscall.Signal(0)) == nil {
+		log.Fatalf("nevinho is already running (PID %d)", pid)
+	}
+}
+
+func writePID(configDir string) {
+	os.WriteFile(pidPath(configDir), []byte(fmt.Sprintf("%d\n", os.Getpid())), 0644)
 }
 
 func detectProvider(cfg *config.Config) llm.Provider {

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -164,7 +164,7 @@ Type=simple
 ExecStart=%s serve
 Restart=on-failure
 RestartSec=10
-TimeoutStopSec=5
+TimeoutStopSec=30
 Environment=HOME=%s
 
 [Install]

--- a/discord/bot.go
+++ b/discord/bot.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	maxImageBytes  = 5 * 1024 * 1024
+	maxImageBytes       = 5 * 1024 * 1024
 	maxImagesPerMessage = 4
 )
 
@@ -39,12 +39,10 @@ func New(token, ownerID string, a *agent.Agent, cfg *config.Config) (*Bot, error
 		return nil, fmt.Errorf("failed to create Discord session: %w", err)
 	}
 
-	// nevinho is DM only. Discord exempts DMs from MESSAGE_CONTENT, so we
-	// receive full message content with just the DirectMessages intent.
-	// Dropping the privileged intent removes a setup foot gun (no toggle
-	// to flip in the developer portal) and avoids a class of session close
-	// errors when that toggle is off.
-	session.Identify.Intents = discordgo.IntentsDirectMessages
+	// nevinho is DM only. Discord exempts DMs from MESSAGE_CONTENT, but
+	// we include it as a hedge against API regressions. The privileged
+	// intent must be enabled in the Developer Portal.
+	session.Identify.Intents = discordgo.IntentsDirectMessages | discordgo.IntentsMessageContent
 
 	bot := &Bot{
 		session: session,
@@ -260,6 +258,11 @@ func (b *Bot) onInteraction(s *discordgo.Session, i *discordgo.InteractionCreate
 }
 
 func (b *Bot) onMessage(s *discordgo.Session, m *discordgo.MessageCreate) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("panic in onMessage: %v", r)
+		}
+	}()
 	if s.State != nil && s.State.User != nil && m.Author.ID == s.State.User.ID {
 		return
 	}


### PR DESCRIPTION
## Summary

- Restore `IntentsMessageContent` to fix silent message drops on service startup
- Add PID file check to prevent duplicate instances (`nevinho serve` + `nevinho start` simultaneously)
- Fix `summarizeAndPrepend` hang by replacing `context.Background()` with 30s timeout
- Add `defer recover()` in `onMessage` to prevent panics from silently dropping events
- Bump `TimeoutStopSec=5` → `TimeoutStopSec=30` in systemd unit to match PersistAll timeout

### Changes

| File | Change |
|---|---|
| `discord/bot.go` | Restored `IntentsMessageContent`; added `defer recover()` in `onMessage` |
| `agent/agent.go` | `summarizeAndPrepend` uses `context.WithTimeout(30s)` instead of `context.Background()` |
| `cmd/serve.go` | PID file check on start, write after successful connect, remove on shutdown |
| `cmd/service.go` | `TimeoutStopSec=5` → `TimeoutStopSec=30` |