### PR TITLE
feat(cli): nevinho chat repl

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/lucasnevespereira/nevinho/agent"
+	"github.com/lucasnevespereira/nevinho/config"
+)
+
+const chatUserID = "cli-local"
+
+// Chat starts a local REPL talking to the same agent core that Discord uses.
+// Useful for debugging when Discord is misbehaving and you want to confirm
+// the agent + LLM + tools chain works end to end.
+//
+//	nevinho chat       interactive REPL
+//	/quit, /q, exit    leave
+//	/forget            wipe REPL session history
+//	/help              show in-REPL commands
+func Chat(configDir, version, selfDoc string) {
+	cfg, err := config.Load(configDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to load config: %v\n", err)
+		os.Exit(1)
+	}
+	provider := detectProvider(cfg)
+	a := agent.New(provider, cfg, version, selfDoc)
+
+	fmt.Printf("nevinho %s — chatting with %s\n", version, a.Model())
+	fmt.Println("type /quit to exit, /forget to wipe history, /help for more")
+	fmt.Println()
+
+	in := bufio.NewReader(os.Stdin)
+	for {
+		fmt.Print("> ")
+		line, err := in.ReadString('\n')
+		if err != nil {
+			fmt.Println()
+			return
+		}
+		text := strings.TrimSpace(line)
+		if text == "" {
+			continue
+		}
+
+		switch text {
+		case "/quit", "/q", "exit", "quit":
+			return
+		case "/forget":
+			a.ClearHistory(chatUserID)
+			fmt.Println("(history cleared)")
+			continue
+		case "/help":
+			fmt.Println("/quit, /q, exit  leave the REPL")
+			fmt.Println("/forget          wipe history for this session")
+			fmt.Println("/help            this help")
+			continue
+		}
+
+		response, err := a.Chat(chatUserID, text, false, nil)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			continue
+		}
+		fmt.Printf("nevinho: %s\n\n", response)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -35,6 +35,8 @@ func main() {
 		}
 	case "config":
 		cmd.Config(configDir, os.Args[2:])
+	case "chat":
+		cmd.Chat(configDir, version, selfDoc)
 	case "start":
 		cmd.Start(configDir, version, selfDoc)
 	case "stop":
@@ -66,6 +68,7 @@ func printUsage() {
 	fmt.Println("Usage:")
 	fmt.Println("  nevinho setup    configure Discord token and LLM keys")
 	fmt.Println("  nevinho config   view, set, or delete config keys")
+	fmt.Println("  nevinho chat     local REPL with the agent (no Discord)")
 	fmt.Println("  nevinho start    start the bot")
 	fmt.Println("  nevinho stop     stop the bot")
 	fmt.Println("  nevinho logs     show live logs (--full, --last N)")


### PR DESCRIPTION
## What

A `nevinho chat` subcommand that opens a local REPL talking to the same agent core that Discord uses. Bypasses Discord entirely. Useful for debugging when the bot is silent and you want to confirm whether the agent + LLM + tools chain works end to end.

## Changes

- New cmd/chat.go with REPL loop
- Wire `chat` into main.go dispatch and printUsage
- Reuses agent.Chat with a stable cli-local user id

## Limitations (follow-up)

- No approval flow yet, so tools that need approval (bash, file_write outside approved paths) error in REPL
- No image or voice piping
- History is in-memory only