### PR TITLE
Vision tags, gpt-5 catalog, README docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ logger/      colored terminal output
   </tr>
 </table>
 
+## Documentation
+
+- [Architecture](ARCHITECTURE.md) — how nevinho processes a message and manages context
+- [Setup](SETUP.md) — Discord bot creation, VPS install, voice setup
+- [Roadmap](ROADMAP.md) — what's shipped and what's next
+
 ## License
 
 [MIT](LICENSE)

--- a/discord/commands.go
+++ b/discord/commands.go
@@ -295,23 +295,39 @@ func (b *Bot) modelOptions() []discordgo.SelectMenuOption {
 
 	if pc.AnthropicKey != "" {
 		for _, name := range llm.KnownModels["anthropic"] {
-			options = append(options, discordgo.SelectMenuOption{
-				Label:   name,
-				Value:   name,
-				Default: name == current,
-			})
+			options = append(options, modelOption(name, current))
 		}
 	}
 	if pc.OpenAIKey != "" {
 		for _, name := range llm.KnownModels["openai"] {
-			options = append(options, discordgo.SelectMenuOption{
-				Label:   name,
-				Value:   name,
-				Default: name == current,
-			})
+			options = append(options, modelOption(name, current))
 		}
 	}
 	return options
+}
+
+// modelOption builds a Discord select menu option, tagging vision capable
+// models so the operator can see at selection time which ones accept images.
+func modelOption(name, current string) discordgo.SelectMenuOption {
+	desc := ""
+	if llm.ModelSupportsVision(name) {
+		desc = "vision"
+	}
+	return discordgo.SelectMenuOption{
+		Label:       name,
+		Value:       name,
+		Description: desc,
+		Default:     name == current,
+	}
+}
+
+// visionTag returns " (vision)" when the model supports image input, or
+// empty string otherwise. Used in plain-text model listings.
+func visionTag(name string) string {
+	if llm.ModelSupportsVision(name) {
+		return " (vision)"
+	}
+	return ""
 }
 
 func (b *Bot) modelStatus() string {
@@ -324,14 +340,14 @@ func (b *Bot) modelStatus() string {
 	if pc.AnthropicKey != "" {
 		sb.WriteString("**Anthropic**\n")
 		for _, m := range llm.KnownModels["anthropic"] {
-			fmt.Fprintf(&sb, "• `%s`\n", m)
+			fmt.Fprintf(&sb, "• `%s`%s\n", m, visionTag(m))
 		}
 		sb.WriteString("\n")
 	}
 	if pc.OpenAIKey != "" {
 		sb.WriteString("**OpenAI**\n")
 		for _, m := range llm.KnownModels["openai"] {
-			fmt.Fprintf(&sb, "• `%s`\n", m)
+			fmt.Fprintf(&sb, "• `%s`%s\n", m, visionTag(m))
 		}
 		sb.WriteString("\n")
 	}

--- a/llm/image.go
+++ b/llm/image.go
@@ -10,10 +10,14 @@ type Image struct {
 }
 
 // ModelSupportsVision reports whether the given model accepts image input.
-// Conservative. Returns true only for known good model families.
+// Updated as new vision capable model families ship. When in doubt, prefer
+// false so the bot rejects the upload with a clear message rather than
+// silently dropping the image and producing a confusing model reply.
 func ModelSupportsVision(name string) bool {
 	switch {
 	case strings.HasPrefix(name, "claude"):
+		return true
+	case strings.HasPrefix(name, "gpt-5"):
 		return true
 	case strings.HasPrefix(name, "gpt-4o"):
 		return true

--- a/llm/provider.go
+++ b/llm/provider.go
@@ -78,6 +78,9 @@ var KnownModels = map[string][]string{
 		"claude-opus-4-7",
 	},
 	"openai": {
+		"gpt-5-nano",
+		"gpt-5-mini",
+		"gpt-5",
 		"gpt-4o-mini",
 		"gpt-4o",
 		"gpt-4-turbo",


### PR DESCRIPTION
Builds on top of #44.

## Changes

- **\`llm.KnownModels\` adds gpt-5 family** (\`gpt-5-nano\`, \`gpt-5-mini\`, \`gpt-5\`). \`ModelSupportsVision\` now matches \`gpt-5*\` so OpenAI's current vision-capable models are recognized.
- **/model selector tags vision models**. Each option shows a \`vision\` description in the dropdown so users see at selection time which models accept images. Plain text \`/model\` listing also marks them with \` (vision)\`.
- **README links Architecture, Setup, Roadmap**. Standard OSS pattern, makes the existing docs discoverable from the front page.