### PR TITLE
Fix CAVEMAN and ELEPHANT toggle UX

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -91,6 +91,10 @@ func printConfigUsage(w *os.File) {
 func printConfigList(cfg *config.Config) {
 	keys := cfg.Keys()
 	for _, k := range keys {
+		if def, ok := defaultedToggle(k.Name); ok && !k.Set {
+			fmt.Printf("  %-22s  %s (default)\n", k.Name, def)
+			continue
+		}
 		if !k.Set {
 			fmt.Printf("  %-22s  not set\n", k.Name)
 			continue
@@ -104,6 +108,20 @@ func printConfigList(cfg *config.Config) {
 	}
 }
 
+// defaultedToggle returns the effective default value for keys whose
+// semantics treat unset as "use the default". Lets `nevinho config`
+// show CAVEMAN/ELEPHANT as "on (default)" or "off (default)" instead
+// of the misleading "not set".
+func defaultedToggle(key string) (string, bool) {
+	switch key {
+	case "ELEPHANT":
+		return "on", true
+	case "CAVEMAN":
+		return "off", true
+	}
+	return "", false
+}
+
 func printConfigValue(cfg *config.Config, key string, reveal bool) {
 	val, err := cfg.Get(key)
 	if err != nil {
@@ -111,6 +129,10 @@ func printConfigValue(cfg *config.Config, key string, reveal bool) {
 		os.Exit(1)
 	}
 	if val == "" {
+		if def, ok := defaultedToggle(strings.ToUpper(key)); ok {
+			fmt.Printf("%s (default)\n", def)
+			return
+		}
 		fmt.Println("(unset)")
 		return
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -107,24 +107,14 @@ func (c *Config) Get(key string) (string, error) {
 
 func (c *Config) Set(key, value string) error {
 	key = strings.ToUpper(key)
-	if key == "CAVEMAN" {
+	if key == "CAVEMAN" || key == "ELEPHANT" {
 		switch strings.ToLower(value) {
-		case "", "off":
-			value = ""
 		case "on":
 			value = "on"
-		default:
-			return fmt.Errorf("CAVEMAN must be on or off")
-		}
-	}
-	if key == "ELEPHANT" {
-		switch strings.ToLower(value) {
-		case "", "on":
-			value = ""
 		case "off":
 			value = "off"
 		default:
-			return fmt.Errorf("ELEPHANT must be on or off")
+			return fmt.Errorf("%s must be on or off", key)
 		}
 	}
 	c.mu.Lock()


### PR DESCRIPTION
## Symptom

\`\`\`
$ nevinho config set ELEPHANT ON
set ELEPHANT
$ nevinho config get ELEPHANT
(unset)
\`\`\`

User sees "(unset)" right after setting it. Looks broken.

## Cause

\`config.Set\` was normalizing each toggle's default value to the empty string ("CAVEMAN OFF" → \`\"\"\`, "ELEPHANT ON" → \`\"\"\`) so the encrypted store stayed compact. Read paths showed empty as "(unset)" without knowing the toggle's default semantics.

## Fix

- Store \`on\` and \`off\` explicitly for both \`CAVEMAN\` and \`ELEPHANT\`. No silent normalization to empty.
- \`printConfigList\` and \`printConfigValue\` now show \`on (default)\` for unset \`ELEPHANT\` and \`off (default)\` for unset \`CAVEMAN\`. Users see the effective state, not just the stored field.

The runtime semantics (\`ElephantEnabled\`, \`CavemanPrompt\`) were already correct and untouched.