### PR TITLE
Per-run logs and friendly errors for scheduled tasks

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -101,7 +101,7 @@ func startScheduler(a *agent.Agent, bot *discord.Bot, configDir string) (*schedu
 		var msg string
 		switch {
 		case err != nil:
-			msg = fmt.Sprintf("**Schedule `%s` failed**\n%v", s.Name, err)
+			msg = fmt.Sprintf("**Schedule `%s` failed**\n%s", s.Name, discord.FriendlyError(err))
 		case result == "":
 			msg = fmt.Sprintf("**Schedule `%s` ran** (no output)", s.Name)
 		default:

--- a/discord/bot_test.go
+++ b/discord/bot_test.go
@@ -161,12 +161,15 @@ func TestFriendlyError(t *testing.T) {
 		{"503 shows overloaded", "API 503: service unavailable", "overloaded"},
 		{"529 shows overloaded", "API 529: overloaded", "overloaded"},
 		{"connection refused", "connection refused", "reach the API"},
+		{"insufficient_quota shows billing", `{"code":"insufficient_quota"}`, "quota exhausted"},
+		{"exceeded current quota shows billing", "exceeded your current quota", "quota exhausted"},
 		{"unknown error passes through", "something weird", "something weird"},
+		{"long unknown error is truncated", strings.Repeat("x", 500), "…"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := friendlyError(fmt.Errorf("%s", tt.err))
+			got := FriendlyError(fmt.Errorf("%s", tt.err))
 			if !strings.Contains(got, tt.contains) {
 				t.Errorf("got %q, want containing %q", got, tt.contains)
 			}

--- a/discord/commands.go
+++ b/discord/commands.go
@@ -47,23 +47,24 @@ var slashCommands = []*discordgo.ApplicationCommand{
 	{Name: "help", Description: "Show available commands and capabilities"},
 	{
 		Name:        "schedules",
-		Description: "List, pause, resume, or delete scheduled tasks",
+		Description: "List scheduled tasks, view their run history, or manage them",
 		Options: []*discordgo.ApplicationCommandOption{
 			{
 				Type:        discordgo.ApplicationCommandOptionString,
 				Name:        "action",
-				Description: "Action: pause, resume, or delete. Omit to list.",
+				Description: "Action: pause, resume, delete, or logs. Omit to list.",
 				Required:    false,
 				Choices: []*discordgo.ApplicationCommandOptionChoice{
 					{Name: "pause", Value: "pause"},
 					{Name: "resume", Value: "resume"},
 					{Name: "delete", Value: "delete"},
+					{Name: "logs", Value: "logs"},
 				},
 			},
 			{
 				Type:        discordgo.ApplicationCommandOptionString,
 				Name:        "name",
-				Description: "Schedule name. Required for pause, resume, delete.",
+				Description: "Schedule name. Required for pause, resume, delete, logs.",
 				Required:    false,
 			},
 		},
@@ -277,7 +278,7 @@ func (b *Bot) runApproval(s *discordgo.Session, channelID, userID string) {
 	indicator.Close()
 	stopTyping()
 	if err != nil {
-		s.ChannelMessageSend(channelID, friendlyError(err))
+		s.ChannelMessageSend(channelID, FriendlyError(err))
 		return
 	}
 	if response == "" {
@@ -536,8 +537,17 @@ func (b *Bot) scheduleAction(action, name string) string {
 			return fmt.Sprintf("No schedule named `%s`.", name)
 		}
 		return fmt.Sprintf("Deleted `%s`.", name)
+	case "logs":
+		if name == "" {
+			return "Usage: `/schedules logs NAME`"
+		}
+		s, ok := b.schedules.Find(name)
+		if !ok {
+			return fmt.Sprintf("No schedule named `%s`.", name)
+		}
+		return formatScheduleLogs(s)
 	default:
-		return "Unknown action. Use list, pause, resume, or delete."
+		return "Unknown action. Use list, pause, resume, delete, or logs."
 	}
 }
 
@@ -556,9 +566,53 @@ func formatSchedules(list []schedule.Schedule) string {
 		fmt.Fprintf(&sb, "  cron: `%s`\n", s.Cron)
 		fmt.Fprintf(&sb, "  next: %s\n", formatScheduleTime(s.NextRun))
 		fmt.Fprintf(&sb, "  prompt: %s\n", s.Prompt)
+		if len(s.Runs) > 0 {
+			fmt.Fprintf(&sb, "  last: %s\n", formatLastRunInline(s.Runs[0]))
+		}
 	}
-	sb.WriteString("\nManage with `/schedules pause|resume|delete NAME`.")
+	sb.WriteString("\nManage with `/schedules pause|resume|delete|logs NAME`.")
 	return sb.String()
+}
+
+func formatScheduleLogs(s schedule.Schedule) string {
+	if len(s.Runs) == 0 {
+		return fmt.Sprintf("`%s` has no recorded runs yet.", s.Name)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "**Run history for `%s`** (last %d)\n", s.Name, len(s.Runs))
+	for _, r := range s.Runs {
+		mark := "✅"
+		if !r.Success {
+			mark = "❌"
+		}
+		fmt.Fprintf(&sb, "\n%s `%s`  %s",
+			mark,
+			r.StartedAt.Format("2006-01-02 15:04:05"),
+			r.Duration.Truncate(time.Millisecond),
+		)
+		switch {
+		case r.Error != "":
+			fmt.Fprintf(&sb, "\n   %s", truncateText(r.Error, 200))
+		case r.Preview != "":
+			fmt.Fprintf(&sb, "\n   %s", truncateText(r.Preview, 200))
+		}
+	}
+	return sb.String()
+}
+
+func formatLastRunInline(r schedule.RunLog) string {
+	mark := "✅"
+	if !r.Success {
+		mark = "❌"
+	}
+	when := r.StartedAt.Format("Mon 15:04")
+	tail := ""
+	if r.Error != "" {
+		tail = " " + truncateText(r.Error, 80)
+	} else if r.Preview != "" {
+		tail = " " + truncateText(r.Preview, 80)
+	}
+	return fmt.Sprintf("%s %s%s", mark, when, tail)
 }
 
 func formatScheduleTime(t time.Time) string {
@@ -566,4 +620,11 @@ func formatScheduleTime(t time.Time) string {
 		return "never"
 	}
 	return t.Format("Mon 2006-01-02 15:04 MST")
+}
+
+func truncateText(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-1] + "…"
 }

--- a/discord/format.go
+++ b/discord/format.go
@@ -104,24 +104,32 @@ func unclosedFence(text string) (string, bool) {
 	return lang, open
 }
 
-// friendlyError translates an LLM or network error into a one line message
-// the user can act on without seeing the raw stack trace.
-func friendlyError(err error) string {
+// FriendlyError translates an LLM or network error into a one line message
+// the user can act on without seeing the raw provider response.
+func FriendlyError(err error) string {
 	msg := err.Error()
 	switch {
+	case strings.Contains(msg, "insufficient_quota"),
+		strings.Contains(msg, "exceeded your current quota"):
+		return "Provider quota exhausted. Check your billing dashboard and add credit."
 	case strings.Contains(msg, "API 401"):
 		return "API key is invalid or expired. Check `/config`."
-	case strings.Contains(msg, "API 402") || strings.Contains(msg, "insufficient") || strings.Contains(msg, "credit balance"):
+	case strings.Contains(msg, "API 402"),
+		strings.Contains(msg, "credit balance"):
 		return "Insufficient funds on your API account."
 	case strings.Contains(msg, "API 429"):
 		return "Rate limited by the API. Wait a moment and try again."
-	case strings.Contains(msg, "API 529") || strings.Contains(msg, "API 503"):
+	case strings.Contains(msg, "API 529"), strings.Contains(msg, "API 503"):
 		return "API is overloaded. Try again shortly."
 	case strings.Contains(msg, "API 500"):
 		return "API returned a server error. Try again."
-	case strings.Contains(msg, "no such host") || strings.Contains(msg, "connection refused"):
+	case strings.Contains(msg, "no such host"),
+		strings.Contains(msg, "connection refused"):
 		return "Can't reach the API. Check your network."
 	default:
+		if len(msg) > 200 {
+			msg = msg[:199] + "…"
+		}
 		return "Something went wrong: " + msg
 	}
 }

--- a/discord/messages.go
+++ b/discord/messages.go
@@ -128,7 +128,7 @@ func (b *Bot) onMessage(s *discordgo.Session, m *discordgo.MessageCreate) {
 	stopTyping()
 	if err != nil {
 		log.Printf("agent error for user %s: %v", m.Author.ID, err)
-		s.ChannelMessageSend(m.ChannelID, friendlyError(err))
+		s.ChannelMessageSend(m.ChannelID, FriendlyError(err))
 		return
 	}
 

--- a/schedule/runner.go
+++ b/schedule/runner.go
@@ -3,6 +3,7 @@ package schedule
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -125,13 +126,34 @@ func (r *Runner) execute(sched Schedule) {
 	userID := "scheduler:" + sched.ID
 	result, err := safeRun(ctx, r.run, userID, sched.Prompt)
 
-	if updateErr := r.store.recordRun(sched.ID, ranAt); updateErr != nil {
+	log := RunLog{
+		StartedAt: ranAt,
+		Duration:  time.Since(ranAt),
+		Success:   err == nil,
+	}
+	if err != nil {
+		log.Error = err.Error()
+	} else {
+		log.Preview = truncatePreview(result, PreviewMaxLen)
+	}
+
+	if updateErr := r.store.recordRun(sched.ID, log); updateErr != nil {
 		logger.Err(fmt.Errorf("schedule %s: persist run: %w", sched.Name, updateErr))
 	}
 
 	if r.notify != nil {
 		r.notify(sched, result, err)
 	}
+}
+
+// truncatePreview shortens text for inline storage. Returns text unchanged
+// when already within max.
+func truncatePreview(text string, max int) string {
+	text = strings.TrimSpace(text)
+	if len(text) <= max {
+		return text
+	}
+	return text[:max-1] + "…"
 }
 
 // safeRun calls the agent and recovers from any panic so a single bad

--- a/schedule/schedule.go
+++ b/schedule/schedule.go
@@ -49,8 +49,24 @@ const (
 	// interactive cancel path, so the timeout is the safety net.
 	RunTimeout = 5 * time.Minute
 
+	// MaxRunsKept limits the inline run history per schedule.
+	// journalctl stays the source for older history.
+	MaxRunsKept = 10
+
+	// PreviewMaxLen caps the length of a result preview stored in a RunLog.
+	PreviewMaxLen = 200
+
 	storeFile = "schedules.enc"
 )
+
+// RunLog records the outcome of one scheduled run.
+type RunLog struct {
+	StartedAt time.Time     `json:"started_at"`
+	Duration  time.Duration `json:"duration"`
+	Success   bool          `json:"success"`
+	Error     string        `json:"error,omitempty"`
+	Preview   string        `json:"preview,omitempty"`
+}
 
 // Schedule is a saved prompt that runs on a cron timetable.
 type Schedule struct {
@@ -62,6 +78,9 @@ type Schedule struct {
 	LastRun time.Time `json:"last_run,omitempty"`
 	NextRun time.Time `json:"next_run,omitempty"`
 	Created time.Time `json:"created"`
+
+	// Runs is the inline run history. Newest first.
+	Runs []RunLog `json:"runs,omitempty"`
 }
 
 // Store loads, mutates, and persists schedules atomically. Safe for
@@ -227,9 +246,11 @@ func (s *Store) SetEnabled(key string, enabled bool) (Schedule, error) {
 	return Schedule{}, fmt.Errorf("schedule %q not found", key)
 }
 
-// recordRun updates LastRun and NextRun after a run completes. Caller is
-// expected to hold no locks (this acquires the write lock internally).
-func (s *Store) recordRun(id string, ranAt time.Time) error {
+// recordRun appends a RunLog (capped at MaxRunsKept), updates LastRun
+// and NextRun, then saves. On save failure the in-memory state is
+// rolled back so the next tick retries the run instead of silently
+// skipping it.
+func (s *Store) recordRun(id string, log RunLog) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for i, sc := range s.list {
@@ -240,12 +261,35 @@ func (s *Store) recordRun(id string, ranAt time.Time) error {
 		if err != nil {
 			return err
 		}
-		sc.LastRun = ranAt
-		sc.NextRun = parsed.Next(ranAt)
+
+		oldRuns := sc.Runs
+		oldLastRun := sc.LastRun
+		oldNextRun := sc.NextRun
+
+		sc.Runs = prependCapped(sc.Runs, log, MaxRunsKept)
+		sc.LastRun = log.StartedAt
+		sc.NextRun = parsed.Next(log.StartedAt)
 		s.list[i] = sc
-		return s.save()
+
+		if err := s.save(); err != nil {
+			s.list[i].Runs = oldRuns
+			s.list[i].LastRun = oldLastRun
+			s.list[i].NextRun = oldNextRun
+			return err
+		}
+		return nil
 	}
 	return nil
+}
+
+// prependCapped puts log at the head of runs and trims to max entries.
+func prependCapped(runs []RunLog, log RunLog, max int) []RunLog {
+	out := make([]RunLog, 0, max)
+	out = append(out, log)
+	for i := 0; i < len(runs) && len(out) < max; i++ {
+		out = append(out, runs[i])
+	}
+	return out
 }
 
 // dueSchedules returns enabled schedules whose NextRun is at or before

--- a/schedule/schedule_test.go
+++ b/schedule/schedule_test.go
@@ -192,6 +192,89 @@ func TestDueSchedulesSkipsMissedRunsAfterDowntime(t *testing.T) {
 	}
 }
 
+func TestRecordRunAppendsAndCaps(t *testing.T) {
+	s := newTestStore(t)
+	created, err := s.Create("trace", "@daily", "x")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := range MaxRunsKept + 5 {
+		log := RunLog{
+			StartedAt: time.Now().Add(time.Duration(i) * time.Minute),
+			Duration:  time.Second,
+			Success:   true,
+			Preview:   "run " + string(rune('a'+i)),
+		}
+		if err := s.recordRun(created.ID, log); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, _ := s.Find("trace")
+	if len(got.Runs) != MaxRunsKept {
+		t.Errorf("Runs len = %d, want %d", len(got.Runs), MaxRunsKept)
+	}
+	expectNewest := "run " + string(rune('a'+MaxRunsKept+4))
+	if got.Runs[0].Preview != expectNewest {
+		t.Errorf("expected newest first %q, got %q", expectNewest, got.Runs[0].Preview)
+	}
+}
+
+func TestRecordRunUpdatesNextAndLast(t *testing.T) {
+	s := newTestStore(t)
+	created, err := s.Create("ticker", "@every 1h", "x")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ranAt := created.NextRun.Add(2 * time.Minute)
+
+	if err := s.recordRun(created.ID, RunLog{
+		StartedAt: ranAt,
+		Duration:  500 * time.Millisecond,
+		Success:   true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := s.Find("ticker")
+	if !got.LastRun.Equal(ranAt) {
+		t.Errorf("LastRun = %s, want %s", got.LastRun, ranAt)
+	}
+	wantNext := ranAt.Add(time.Hour)
+	if !got.NextRun.Equal(wantNext) {
+		t.Errorf("NextRun = %s, want %s (ranAt + 1h)", got.NextRun, wantNext)
+	}
+}
+
+func TestPrependCappedKeepsNewestFirst(t *testing.T) {
+	older := []RunLog{{Preview: "b"}, {Preview: "c"}}
+	got := prependCapped(older, RunLog{Preview: "a"}, 3)
+
+	want := []string{"a", "b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d", len(got), len(want))
+	}
+	for i, w := range want {
+		if got[i].Preview != w {
+			t.Errorf("got[%d] = %q, want %q", i, got[i].Preview, w)
+		}
+	}
+}
+
+func TestPrependCappedTrims(t *testing.T) {
+	older := []RunLog{{Preview: "b"}, {Preview: "c"}, {Preview: "d"}}
+	got := prependCapped(older, RunLog{Preview: "a"}, 2)
+
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Preview != "a" || got[1].Preview != "b" {
+		t.Errorf("got = %+v, want [a b]", got)
+	}
+}
+
 func TestDueSchedulesReturnsOnlyEnabledAndPastDue(t *testing.T) {
 	s := newTestStore(t)
 	a, _ := s.Create("a", "@daily", "x")

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -252,8 +252,9 @@ Actions:
 - delete: requires name. Removes the schedule.
 - pause: requires name. Disables firing without removing the entry.
 - resume: requires name. Re-enables a paused schedule and recomputes NextRun.
+- logs: requires name. Returns the last 10 runs (timestamp, duration, status, preview or error).
 Output: human readable text. Errors are prefixed with "failed: " or "invalid input:".`,
-			Schema: `{"type":"object","properties":{"action":{"type":"string","enum":["list","create","delete","pause","resume"],"description":"Action to perform"},"name":{"type":"string","description":"Unique schedule name. Required for create, delete, pause, and resume."},"cron":{"type":"string","description":"Cron expression. Required for create. Examples: \"0 9 * * *\", \"@daily\", \"@every 30m\"."},"prompt":{"type":"string","description":"What nevinho should run on each fire. Required for create."}},"required":["action"]}`,
+			Schema: `{"type":"object","properties":{"action":{"type":"string","enum":["list","create","delete","pause","resume","logs"],"description":"Action to perform"},"name":{"type":"string","description":"Unique schedule name. Required for create, delete, pause, resume, and logs."},"cron":{"type":"string","description":"Cron expression. Required for create. Examples: \"0 9 * * *\", \"@daily\", \"@every 30m\"."},"prompt":{"type":"string","description":"What nevinho should run on each fire. Required for create."}},"required":["action"]}`,
 		},
 	}
 }

--- a/tools/schedule.go
+++ b/tools/schedule.go
@@ -60,8 +60,14 @@ func (r *Registry) scheduleTool(input json.RawMessage) string {
 			return "failed: " + err.Error()
 		}
 		return fmt.Sprintf("resumed %q. Next run: %s", s.Name, formatTime(s.NextRun))
+	case "logs":
+		s, ok := store.Find(in.Name)
+		if !ok {
+			return fmt.Sprintf("no schedule named %q", in.Name)
+		}
+		return formatScheduleLogs(s)
 	default:
-		return fmt.Sprintf("unknown action %q. Use list, create, delete, pause, or resume.", in.Action)
+		return fmt.Sprintf("unknown action %q. Use list, create, delete, pause, resume, or logs.", in.Action)
 	}
 }
 
@@ -77,8 +83,64 @@ func formatScheduleList(list []schedule.Schedule) string {
 		}
 		fmt.Fprintf(&sb, "%s [%s] %s\n  cron: %s\n  next: %s\n  prompt: %s\n",
 			s.Name, state, s.ID, s.Cron, formatTime(s.NextRun), truncate(s.Prompt, 80))
+		if last := lastRun(s); last != nil {
+			fmt.Fprintf(&sb, "  last: %s\n", formatLastRun(*last))
+		}
 	}
 	return strings.TrimRight(sb.String(), "\n")
+}
+
+func formatScheduleLogs(s schedule.Schedule) string {
+	if len(s.Runs) == 0 {
+		return fmt.Sprintf("%s has no recorded runs yet", s.Name)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%s last %d run(s):\n", s.Name, len(s.Runs))
+	for _, r := range s.Runs {
+		mark := "ok"
+		if !r.Success {
+			mark = "fail"
+		}
+		fmt.Fprintf(&sb, "  %s  %s  %s",
+			r.StartedAt.Format("2006-01-02 15:04:05"),
+			r.Duration.Truncate(time.Millisecond),
+			mark,
+		)
+		if r.Error != "" {
+			fmt.Fprintf(&sb, "  %s", truncate(r.Error, 120))
+		} else if r.Preview != "" {
+			fmt.Fprintf(&sb, "  %s", truncate(r.Preview, 120))
+		}
+		sb.WriteString("\n")
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+// lastRun returns the most recent run, or nil if none.
+func lastRun(s schedule.Schedule) *schedule.RunLog {
+	if len(s.Runs) == 0 {
+		return nil
+	}
+	r := s.Runs[0]
+	return &r
+}
+
+func formatLastRun(r schedule.RunLog) string {
+	mark := "ok"
+	if !r.Success {
+		mark = "fail"
+	}
+	tail := ""
+	if r.Error != "" {
+		tail = " " + truncate(r.Error, 80)
+	} else if r.Preview != "" {
+		tail = " " + truncate(r.Preview, 80)
+	}
+	return fmt.Sprintf("%s %s%s",
+		r.StartedAt.Format("2006-01-02 15:04"),
+		mark,
+		tail,
+	)
 }
 
 func formatTime(t time.Time) string {


### PR DESCRIPTION
Two complementary improvements to the schedule feature shipped in v0.12.

## What

### Per-run logs

Each schedule keeps the last 10 run outcomes inline (timestamp, duration, success/error, preview). Older history stays in journalctl.

- New \`RunLog\` type recorded on every fire.
- \`/schedules\` listing now shows the last run inline (status + 80 char preview).
- New \`/schedules logs NAME\` command shows the full last 10 entries.
- Agent tool gains a \`logs\` action so the model can answer "did my morning HN schedule fail recently?".
- \`recordRun\` is atomic: if save fails, in memory state rolls back so the next tick retries.

### Friendly errors in notifications

The schedule notify hook used to dump the raw provider error JSON straight to Discord. It now goes through \`FriendlyError\` like interactive chat does.

- \`friendlyError\` exported as \`FriendlyError\` for use from the scheduler.
- New case for \`insufficient_quota\` and \`exceeded your current quota\` (the actual messages OpenAI returns when your billing runs out).
- Default fallback truncates at 200 chars instead of dumping multi line JSON.

## Why this design

- Logs inline in the Schedule struct rather than a separate file. nevinho caps at 10 schedules and 10 runs each, so 100 entries max. Keeping them in one encrypted file is simpler than a second store.
- Atomic recordRun with rollback so a disk full does not silently skip runs.
- \`FriendlyError\` exported so background workers reuse the same translation users already see in chat. No second source of truth.

## Tests

- \`TestRecordRunAppendsAndCaps\` covers the cap logic.
- \`TestRecordRunUpdatesNextAndLast\` verifies LastRun and NextRun progression.
- \`TestPrependCappedKeepsNewestFirst\` and \`TestPrependCappedTrims\` cover the helper.
- New cases in \`TestFriendlyError\` for insufficient_quota and the truncated fallback.

234 tests pass.