### PR TITLE
Per-schedule timezone for cron evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Limits: 10 schedules total, 5 minute minimum interval, 5 minute per-run timeout.
 
 Cron accepts standard 5-field expressions (`0 9 * * *`), descriptors (`@daily`, `@hourly`, `@weekly`), and durations (`@every 30m`, `@every 6h`).
 
-> **Time zone**: schedules use the VPS's local time. If your host runs UTC, `0 9 * * *` fires at 9am UTC. Tell the agent the timezone you want ("every day at 9am Paris time") so it picks the right hour, or check `date` on the server first.
+> **Time zone**: schedules accept an IANA timezone (e.g. `Europe/Paris`, `America/New_York`). The agent picks one up from natural language ("every day at 9am Paris time"). Without one, the cron is evaluated in the VPS's local time.
 
 ## Commands
 

--- a/discord/commands.go
+++ b/discord/commands.go
@@ -524,7 +524,7 @@ func (b *Bot) scheduleAction(action, name string) string {
 		if action == "pause" {
 			return fmt.Sprintf("Paused `%s`.", s.Name)
 		}
-		return fmt.Sprintf("Resumed `%s`. Next run: %s", s.Name, formatScheduleTime(s.NextRun))
+		return fmt.Sprintf("Resumed `%s`. Next run: %s", s.Name, formatScheduleNext(s))
 	case "delete":
 		if name == "" {
 			return "Usage: `/schedules delete NAME`"
@@ -563,8 +563,8 @@ func formatSchedules(list []schedule.Schedule) string {
 			state = "⏸"
 		}
 		fmt.Fprintf(&sb, "\n%s `%s`\n", state, s.Name)
-		fmt.Fprintf(&sb, "  cron: `%s`\n", s.Cron)
-		fmt.Fprintf(&sb, "  next: %s\n", formatScheduleTime(s.NextRun))
+		fmt.Fprintf(&sb, "  cron: `%s`%s\n", s.Cron, formatTzSuffix(s.Timezone))
+		fmt.Fprintf(&sb, "  next: %s\n", formatScheduleNext(s))
 		fmt.Fprintf(&sb, "  prompt: %s\n", s.Prompt)
 		if len(s.Runs) > 0 {
 			fmt.Fprintf(&sb, "  last: %s\n", formatLastRunInline(s.Runs[0]))
@@ -572,6 +572,28 @@ func formatSchedules(list []schedule.Schedule) string {
 	}
 	sb.WriteString("\nManage with `/schedules pause|resume|delete|logs NAME`.")
 	return sb.String()
+}
+
+func formatTzSuffix(tz string) string {
+	if tz == "" {
+		return ""
+	}
+	return " (" + tz + ")"
+}
+
+// formatScheduleNext renders NextRun in the schedule's own timezone when set,
+// so the operator reads the time in the zone they configured.
+func formatScheduleNext(s schedule.Schedule) string {
+	if s.NextRun.IsZero() {
+		return "never"
+	}
+	t := s.NextRun
+	if s.Timezone != "" {
+		if loc, err := time.LoadLocation(s.Timezone); err == nil {
+			t = t.In(loc)
+		}
+	}
+	return t.Format("Mon 2006-01-02 15:04 MST")
 }
 
 func formatScheduleLogs(s schedule.Schedule) string {
@@ -613,13 +635,6 @@ func formatLastRunInline(r schedule.RunLog) string {
 		tail = " " + truncateText(r.Preview, 80)
 	}
 	return fmt.Sprintf("%s %s%s", mark, when, tail)
-}
-
-func formatScheduleTime(t time.Time) string {
-	if t.IsZero() {
-		return "never"
-	}
-	return t.Format("Mon 2006-01-02 15:04 MST")
 }
 
 func truncateText(s string, n int) string {

--- a/schedule/cron.go
+++ b/schedule/cron.go
@@ -17,7 +17,20 @@ import (
 var parser = cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
 
 func parseCron(expr string) (cron.Schedule, error) {
+	return parseCronInTimezone(expr, "")
+}
+
+// parseCronInTimezone parses a cron expression in the given IANA timezone.
+// An empty timezone falls back to the server's local time. Wires the
+// timezone into robfig/cron via its CRON_TZ= prefix syntax.
+func parseCronInTimezone(expr, tz string) (cron.Schedule, error) {
 	expr = strings.TrimSpace(expr)
+	if tz != "" {
+		if _, err := time.LoadLocation(tz); err != nil {
+			return nil, fmt.Errorf("invalid timezone %q", tz)
+		}
+		expr = "CRON_TZ=" + tz + " " + expr
+	}
 	return parser.Parse(expr)
 }
 

--- a/schedule/cron_test.go
+++ b/schedule/cron_test.go
@@ -57,3 +57,40 @@ func TestMinIntervalEvery30m(t *testing.T) {
 		t.Errorf("minInterval(@every 30m) = %s, want 30m", got)
 	}
 }
+
+func TestParseCronInTimezoneAcceptsValidTZ(t *testing.T) {
+	for _, tz := range []string{"Europe/Paris", "America/New_York", "Asia/Tokyo", "UTC"} {
+		if _, err := parseCronInTimezone("0 9 * * *", tz); err != nil {
+			t.Errorf("%s should be valid: %v", tz, err)
+		}
+	}
+}
+
+func TestParseCronInTimezoneRejectsInvalidTZ(t *testing.T) {
+	for _, tz := range []string{"Europe/Pariss", "Mars/Olympus_Mons", "not-a-tz"} {
+		if _, err := parseCronInTimezone("0 9 * * *", tz); err == nil {
+			t.Errorf("%s should be invalid", tz)
+		}
+	}
+}
+
+func TestParseCronInTimezoneFiresInThatZone(t *testing.T) {
+	paris, _ := time.LoadLocation("Europe/Paris")
+	utc, _ := time.LoadLocation("UTC")
+
+	sched, err := parseCronInTimezone("0 9 * * *", "Europe/Paris")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// In summer (CEST = UTC+2), 9am Paris = 7am UTC.
+	noonUTC := time.Date(2026, 7, 1, 0, 0, 0, 0, utc)
+	next := sched.Next(noonUTC)
+
+	if h := next.UTC().Hour(); h != 7 {
+		t.Errorf("next fire UTC hour = %d, want 7 (= 9am Paris CEST)", h)
+	}
+	if h := next.In(paris).Hour(); h != 9 {
+		t.Errorf("next fire Paris hour = %d, want 9", h)
+	}
+}

--- a/schedule/schedule.go
+++ b/schedule/schedule.go
@@ -79,6 +79,10 @@ type Schedule struct {
 	NextRun time.Time `json:"next_run,omitempty"`
 	Created time.Time `json:"created"`
 
+	// Timezone is the IANA name (e.g. "Europe/Paris") used to evaluate
+	// the cron expression. Empty means the server's local time.
+	Timezone string `json:"timezone,omitempty"`
+
 	// Runs is the inline run history. Newest first.
 	Runs []RunLog `json:"runs,omitempty"`
 }
@@ -162,16 +166,20 @@ func (s *Store) Find(key string) (Schedule, bool) {
 // Create validates and persists a new schedule. Names must be unique.
 // The cron expression is parsed and the first NextRun is computed before
 // storing so the runner does not need to revalidate on every tick.
-func (s *Store) Create(name, cronExpr, prompt string) (Schedule, error) {
+//
+// Pass tz as an IANA timezone name (e.g. "Europe/Paris") to evaluate
+// the cron in that location. Empty tz uses the server's local time.
+func (s *Store) Create(name, cronExpr, prompt, tz string) (Schedule, error) {
 	name = trim(name)
 	cronExpr = trim(cronExpr)
 	prompt = trim(prompt)
+	tz = trim(tz)
 
 	if name == "" || cronExpr == "" || prompt == "" {
 		return Schedule{}, fmt.Errorf("name, cron, and prompt are required")
 	}
 
-	sched, err := parseCron(cronExpr)
+	sched, err := parseCronInTimezone(cronExpr, tz)
 	if err != nil {
 		return Schedule{}, fmt.Errorf("invalid cron %q: %w", cronExpr, err)
 	}
@@ -193,13 +201,14 @@ func (s *Store) Create(name, cronExpr, prompt string) (Schedule, error) {
 
 	now := time.Now()
 	entry := Schedule{
-		ID:      newID(),
-		Name:    name,
-		Cron:    cronExpr,
-		Prompt:  prompt,
-		Enabled: true,
-		NextRun: sched.Next(now),
-		Created: now,
+		ID:       newID(),
+		Name:     name,
+		Cron:     cronExpr,
+		Prompt:   prompt,
+		Enabled:  true,
+		NextRun:  sched.Next(now),
+		Created:  now,
+		Timezone: tz,
 	}
 	s.list = append(s.list, entry)
 	if err := s.save(); err != nil {
@@ -234,7 +243,7 @@ func (s *Store) SetEnabled(key string, enabled bool) (Schedule, error) {
 		}
 		sc.Enabled = enabled
 		if enabled {
-			parsed, err := parseCron(sc.Cron)
+			parsed, err := parseCronInTimezone(sc.Cron, sc.Timezone)
 			if err != nil {
 				return Schedule{}, err
 			}
@@ -257,7 +266,7 @@ func (s *Store) recordRun(id string, log RunLog) error {
 		if sc.ID != id {
 			continue
 		}
-		parsed, err := parseCron(sc.Cron)
+		parsed, err := parseCronInTimezone(sc.Cron, sc.Timezone)
 		if err != nil {
 			return err
 		}
@@ -314,7 +323,7 @@ func (s *Store) dueSchedules(now time.Time) []Schedule {
 		if sc.NextRun.After(now) {
 			continue
 		}
-		parsed, err := parseCron(sc.Cron)
+		parsed, err := parseCronInTimezone(sc.Cron, sc.Timezone)
 		if err != nil {
 			continue
 		}

--- a/schedule/schedule_test.go
+++ b/schedule/schedule_test.go
@@ -18,7 +18,7 @@ func newTestStore(t *testing.T) *Store {
 
 func TestCreateAndList(t *testing.T) {
 	s := newTestStore(t)
-	got, err := s.Create("morning-hn", "@daily", "summarize HN")
+	got, err := s.Create("morning-hn", "@daily", "summarize HN", "")
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -38,38 +38,66 @@ func TestCreateAndList(t *testing.T) {
 
 func TestCreateRejectsDuplicateName(t *testing.T) {
 	s := newTestStore(t)
-	if _, err := s.Create("daily", "@daily", "x"); err != nil {
+	if _, err := s.Create("daily", "@daily", "x", ""); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.Create("daily", "@hourly", "y"); err == nil {
+	if _, err := s.Create("daily", "@hourly", "y", ""); err == nil {
 		t.Fatal("expected duplicate-name error")
 	}
 }
 
 func TestCreateRejectsTooFrequent(t *testing.T) {
 	s := newTestStore(t)
-	_, err := s.Create("spam", "@every 1m", "x")
+	_, err := s.Create("spam", "@every 1m", "x", "")
 	if err == nil || !strings.Contains(err.Error(), "minimum") {
 		t.Errorf("expected min-interval error, got %v", err)
 	}
 }
 
+func TestCreateWithTimezone(t *testing.T) {
+	s := newTestStore(t)
+	got, err := s.Create("paris-morning", "0 9 * * *", "summarize", "Europe/Paris")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Timezone != "Europe/Paris" {
+		t.Errorf("Timezone = %q, want Europe/Paris", got.Timezone)
+	}
+
+	// Reload to confirm persistence.
+	loaded, err := LoadStore(s.dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got2, _ := loaded.Find("paris-morning")
+	if got2.Timezone != "Europe/Paris" {
+		t.Errorf("after reload Timezone = %q, want Europe/Paris", got2.Timezone)
+	}
+}
+
+func TestCreateRejectsInvalidTimezone(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.Create("bad-tz", "0 9 * * *", "x", "Europe/Pariss"); err == nil {
+		t.Error("expected invalid timezone to error")
+	}
+}
+
 func TestCreateRejectsBadCron(t *testing.T) {
 	s := newTestStore(t)
-	if _, err := s.Create("bad", "every monday", "x"); err == nil {
+	if _, err := s.Create("bad", "every monday", "x", ""); err == nil {
 		t.Fatal("expected parse error")
 	}
 }
 
 func TestCreateRejectsMissingFields(t *testing.T) {
 	s := newTestStore(t)
-	if _, err := s.Create("", "@daily", "x"); err == nil {
+	if _, err := s.Create("", "@daily", "x", ""); err == nil {
 		t.Error("missing name should error")
 	}
-	if _, err := s.Create("a", "", "x"); err == nil {
+	if _, err := s.Create("a", "", "x", ""); err == nil {
 		t.Error("missing cron should error")
 	}
-	if _, err := s.Create("a", "@daily", ""); err == nil {
+	if _, err := s.Create("a", "@daily", "", ""); err == nil {
 		t.Error("missing prompt should error")
 	}
 }
@@ -78,18 +106,18 @@ func TestCreateEnforcesMaxSchedules(t *testing.T) {
 	s := newTestStore(t)
 	for i := range MaxSchedules {
 		name := "s" + string(rune('A'+i))
-		if _, err := s.Create(name, "@daily", "x"); err != nil {
+		if _, err := s.Create(name, "@daily", "x", ""); err != nil {
 			t.Fatalf("Create %s: %v", name, err)
 		}
 	}
-	if _, err := s.Create("overflow", "@daily", "x"); err == nil {
+	if _, err := s.Create("overflow", "@daily", "x", ""); err == nil {
 		t.Error("expected max-schedules error")
 	}
 }
 
 func TestDelete(t *testing.T) {
 	s := newTestStore(t)
-	if _, err := s.Create("doomed", "@daily", "x"); err != nil {
+	if _, err := s.Create("doomed", "@daily", "x", ""); err != nil {
 		t.Fatal(err)
 	}
 	ok, err := s.Delete("doomed")
@@ -117,7 +145,7 @@ func TestDeleteMissing(t *testing.T) {
 
 func TestSetEnabledTogglesAndRefreshesNextRun(t *testing.T) {
 	s := newTestStore(t)
-	created, err := s.Create("toggleable", "@daily", "x")
+	created, err := s.Create("toggleable", "@daily", "x", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,7 +177,7 @@ func TestPersistsAcrossLoads(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s1.Create("persist-me", "@daily", "x"); err != nil {
+	if _, err := s1.Create("persist-me", "@daily", "x", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -165,7 +193,7 @@ func TestPersistsAcrossLoads(t *testing.T) {
 
 func TestDueSchedulesSkipsMissedRunsAfterDowntime(t *testing.T) {
 	s := newTestStore(t)
-	created, err := s.Create("hourly", "@every 1h", "x")
+	created, err := s.Create("hourly", "@every 1h", "x", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -194,7 +222,7 @@ func TestDueSchedulesSkipsMissedRunsAfterDowntime(t *testing.T) {
 
 func TestRecordRunAppendsAndCaps(t *testing.T) {
 	s := newTestStore(t)
-	created, err := s.Create("trace", "@daily", "x")
+	created, err := s.Create("trace", "@daily", "x", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +251,7 @@ func TestRecordRunAppendsAndCaps(t *testing.T) {
 
 func TestRecordRunUpdatesNextAndLast(t *testing.T) {
 	s := newTestStore(t)
-	created, err := s.Create("ticker", "@every 1h", "x")
+	created, err := s.Create("ticker", "@every 1h", "x", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -277,8 +305,8 @@ func TestPrependCappedTrims(t *testing.T) {
 
 func TestDueSchedulesReturnsOnlyEnabledAndPastDue(t *testing.T) {
 	s := newTestStore(t)
-	a, _ := s.Create("a", "@daily", "x")
-	_, _ = s.Create("b", "@daily", "x")
+	a, _ := s.Create("a", "@daily", "x", "")
+	_, _ = s.Create("b", "@daily", "x", "")
 	_, _ = s.SetEnabled("b", false)
 
 	// Force a's NextRun to the past.

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -246,6 +246,7 @@ Use to set up "every morning at 9 summarize hacker news", "every Monday list my 
 Translate the user's natural language into a cron expression yourself. Do not ask the user to write cron.
 Schedules run without an interactive approval prompt, so refuse to create schedules whose prompts would normally need approval (destructive bash, file writes outside approved paths). Suggest a safer prompt instead.
 Cron accepts standard 5-field expressions ("0 9 * * *"), descriptors (@daily, @hourly, @weekly), and durations (@every 30m, @every 6h). Minimum interval is 5 minutes. Maximum 10 schedules total.
+Timezones: pass an IANA name (e.g. "Europe/Paris", "America/New_York") via the timezone argument when the user mentions a city or zone. The cron expression is then evaluated in that timezone. Without a timezone, the server's local time is used.
 Actions:
 - list: returns every schedule with its cron, next run, and current state. Default action when "action" is omitted.
 - create: requires name, cron, and prompt. Returns the new entry with its first NextRun.
@@ -254,7 +255,7 @@ Actions:
 - resume: requires name. Re-enables a paused schedule and recomputes NextRun.
 - logs: requires name. Returns the last 10 runs (timestamp, duration, status, preview or error).
 Output: human readable text. Errors are prefixed with "failed: " or "invalid input:".`,
-			Schema: `{"type":"object","properties":{"action":{"type":"string","enum":["list","create","delete","pause","resume","logs"],"description":"Action to perform"},"name":{"type":"string","description":"Unique schedule name. Required for create, delete, pause, resume, and logs."},"cron":{"type":"string","description":"Cron expression. Required for create. Examples: \"0 9 * * *\", \"@daily\", \"@every 30m\"."},"prompt":{"type":"string","description":"What nevinho should run on each fire. Required for create."}},"required":["action"]}`,
+			Schema: `{"type":"object","properties":{"action":{"type":"string","enum":["list","create","delete","pause","resume","logs"],"description":"Action to perform"},"name":{"type":"string","description":"Unique schedule name. Required for create, delete, pause, resume, and logs."},"cron":{"type":"string","description":"Cron expression. Required for create. Examples: \"0 9 * * *\", \"@daily\", \"@every 30m\"."},"prompt":{"type":"string","description":"What nevinho should run on each fire. Required for create."},"timezone":{"type":"string","description":"Optional IANA timezone (e.g. \"Europe/Paris\"). When set, the cron is evaluated in this zone."}},"required":["action"]}`,
 		},
 	}
 }

--- a/tools/schedule.go
+++ b/tools/schedule.go
@@ -10,10 +10,11 @@ import (
 )
 
 type scheduleInput struct {
-	Action string `json:"action"`
-	Name   string `json:"name"`
-	Cron   string `json:"cron"`
-	Prompt string `json:"prompt"`
+	Action   string `json:"action"`
+	Name     string `json:"name"`
+	Cron     string `json:"cron"`
+	Prompt   string `json:"prompt"`
+	Timezone string `json:"timezone"`
 }
 
 func (r *Registry) scheduleTool(input json.RawMessage) string {
@@ -34,11 +35,11 @@ func (r *Registry) scheduleTool(input json.RawMessage) string {
 	case "", "list":
 		return formatScheduleList(store.All())
 	case "create":
-		s, err := store.Create(in.Name, in.Cron, in.Prompt)
+		s, err := store.Create(in.Name, in.Cron, in.Prompt, in.Timezone)
 		if err != nil {
 			return "failed: " + err.Error()
 		}
-		return fmt.Sprintf("created %q. Next run: %s", s.Name, formatTime(s.NextRun))
+		return fmt.Sprintf("created %q. Next run: %s", s.Name, formatScheduledTime(s))
 	case "delete":
 		ok, err := store.Delete(in.Name)
 		if err != nil {
@@ -59,7 +60,7 @@ func (r *Registry) scheduleTool(input json.RawMessage) string {
 		if err != nil {
 			return "failed: " + err.Error()
 		}
-		return fmt.Sprintf("resumed %q. Next run: %s", s.Name, formatTime(s.NextRun))
+		return fmt.Sprintf("resumed %q. Next run: %s", s.Name, formatScheduledTime(s))
 	case "logs":
 		s, ok := store.Find(in.Name)
 		if !ok {
@@ -81,13 +82,41 @@ func formatScheduleList(list []schedule.Schedule) string {
 		if !s.Enabled {
 			state = "paused"
 		}
-		fmt.Fprintf(&sb, "%s [%s] %s\n  cron: %s\n  next: %s\n  prompt: %s\n",
-			s.Name, state, s.ID, s.Cron, formatTime(s.NextRun), truncate(s.Prompt, 80))
+		fmt.Fprintf(&sb, "%s [%s] %s\n  cron: %s%s\n  next: %s\n  prompt: %s\n",
+			s.Name, state, s.ID,
+			s.Cron, tzSuffix(s.Timezone),
+			formatScheduledTime(s),
+			truncate(s.Prompt, 80),
+		)
 		if last := lastRun(s); last != nil {
 			fmt.Fprintf(&sb, "  last: %s\n", formatLastRun(*last))
 		}
 	}
 	return strings.TrimRight(sb.String(), "\n")
+}
+
+// formatScheduledTime renders the schedule's NextRun in its own timezone
+// when one is set, falling back to server local time. Helps the operator
+// read the next fire in the time zone they configured the schedule for.
+func formatScheduledTime(s schedule.Schedule) string {
+	if s.NextRun.IsZero() {
+		return "never"
+	}
+	t := s.NextRun
+	if s.Timezone != "" {
+		if loc, err := time.LoadLocation(s.Timezone); err == nil {
+			t = t.In(loc)
+		}
+	}
+	return t.Format("2006-01-02 15:04 MST")
+}
+
+// tzSuffix renders " (Europe/Paris)" when set, empty otherwise.
+func tzSuffix(tz string) string {
+	if tz == "" {
+		return ""
+	}
+	return " (" + tz + ")"
 }
 
 func formatScheduleLogs(s schedule.Schedule) string {
@@ -141,13 +170,6 @@ func formatLastRun(r schedule.RunLog) string {
 		mark,
 		tail,
 	)
-}
-
-func formatTime(t time.Time) string {
-	if t.IsZero() {
-		return "never"
-	}
-	return t.Format("2006-01-02 15:04 MST")
 }
 
 func truncate(s string, n int) string {


### PR DESCRIPTION
## What

Each schedule can now carry an IANA timezone (e.g. \`Europe/Paris\`, \`America/New_York\`). The cron expression is evaluated in that timezone instead of the VPS local time.

## Why

Without this, \`0 9 * * *\` on a UTC VPS fires at 9am UTC, which is 11am for a Paris user. People expect "9am" to mean their 9am.

## Design

- New \`Timezone\` field on \`Schedule\` (IANA name, optional). Empty falls back to server local.
- \`parseCronInTimezone(expr, tz)\` wraps the existing parser, prepending robfig/cron's native \`CRON_TZ=\` prefix when a timezone is set. \`time.LoadLocation\` validates the name first.
- \`Create\` takes an extra \`tz\` arg, validated and stored.
- \`recordRun\`, \`SetEnabled\`, and \`dueSchedules\` all use \`parseCronInTimezone(sc.Cron, sc.Timezone)\` so re-parses stay consistent with the original.
- Tool agent accepts an optional \`timezone\` param. The model picks one up from natural language ("every day at 9am Paris time").
- Display renders \`NextRun.In(loc)\` so the operator reads the next fire in the zone they configured.

The library does the heavy lifting. We do not reinvent timezone math.

## Tests

- \`TestParseCronInTimezoneAcceptsValidTZ\` and \`TestParseCronInTimezoneRejectsInvalidTZ\` cover validation.
- \`TestParseCronInTimezoneFiresInThatZone\` verifies a Paris cron actually fires at the right UTC moment in summer (DST aware).
- \`TestCreateWithTimezone\` covers persistence round-trip.
- \`TestCreateRejectsInvalidTimezone\` covers the validation path through Create.
- All existing tests still pass with an empty timezone arg. 239 tests total.

## UX

Natural language entry:
> "every morning at 9 Paris time, summarize HN"

\`/schedules\` listing:
\`\`\`
▶ morning-hn
  cron: \`0 9 * * *\` (Europe/Paris)
  next: Sat 2026-05-11 09:00 CEST
  prompt: summarize HN
\`\`\`

The operator sees the time in the zone they asked for. No mental math.