### PR TITLE
Pin a model per schedule via ChatRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Cron accepts standard 5-field expressions (`0 9 * * *`), descriptors (`@daily`, 
 
 > **Time zone**: schedules accept an IANA timezone (e.g. `Europe/Paris`, `America/New_York`). The agent picks one up from natural language ("every day at 9am Paris time"). Without one, the cron is evaluated in the VPS's local time.
 
+> **Model**: schedules can pin a specific model ("use Haiku, it's enough"). Useful when most schedules can run cheap (Haiku) while interactive chat stays on Sonnet. Without one, the agent's currently selected model is used at run time.
+
 ## Commands
 
 | Command             | What it does                              |

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -137,7 +137,37 @@ func (a *Agent) Cancel(userID string) bool {
 	return false
 }
 
-func (a *Agent) Chat(userID, text string, isVoice bool, images []llm.Image) (string, error) {
+// ChatRequest carries the inputs of one chat turn. Optional fields can
+// override the agent's defaults for that turn only without mutating the
+// agent's state. Future options (max tokens, temperature, system prompt
+// override) belong here too.
+type ChatRequest struct {
+	UserID  string
+	Text    string
+	IsVoice bool
+	Images  []llm.Image
+
+	// Model, when set, overrides the agent's selected provider for this
+	// call only. Useful for scheduled runs that pin a specific model
+	// regardless of what the operator currently chats with.
+	Model string
+}
+
+func (a *Agent) Chat(req ChatRequest) (string, error) {
+	provider := a.llm
+	if req.Model != "" {
+		p, err := llm.Resolve(req.Model, a.cfg.ProviderConfig())
+		if err != nil {
+			return "", fmt.Errorf("resolve model %q: %w", req.Model, err)
+		}
+		provider = p
+	}
+
+	userID := req.UserID
+	text := req.Text
+	isVoice := req.IsVoice
+	images := req.Images
+
 	lock := a.getUserLock(userID)
 	lock.Lock()
 	defer lock.Unlock()
@@ -208,7 +238,7 @@ func (a *Agent) Chat(userID, text string, isVoice bool, images []llm.Image) (str
 
 	a.maybeLoadSummary(userID)
 
-	if evicted := a.appendHistory(userID, a.llm.FormatUserMessage(text, images)); len(evicted) > 2 {
+	if evicted := a.appendHistory(userID, provider.FormatUserMessage(text, images)); len(evicted) > 2 {
 		a.summarizeAndPrepend(userID, evicted)
 	}
 
@@ -216,7 +246,7 @@ func (a *Agent) Chat(userID, text string, isVoice bool, images []llm.Image) (str
 		if ctx.Err() != nil {
 			return "Cancelled.", nil
 		}
-		resp, err := a.llm.Complete(ctx, &llm.Request{
+		resp, err := provider.Complete(ctx, &llm.Request{
 			SystemPrompt: prompt,
 			Messages:     a.history[userID],
 			Tools:        a.tools.Defs(),
@@ -234,7 +264,7 @@ func (a *Agent) Chat(userID, text string, isVoice bool, images []llm.Image) (str
 
 		if len(resp.ToolCalls) == 0 {
 			a.addTokens(usage.In, usage.Out)
-			logger.Done(start, usage.In, usage.Out, cacheRead, toolsUsed, estimateCost(a.llm.Model(), usage.In, usage.Out))
+			logger.Done(start, usage.In, usage.Out, cacheRead, toolsUsed, estimateCost(provider.Model(), usage.In, usage.Out))
 			logger.Nevinho(resp.Text)
 			return resp.Text, nil
 		}
@@ -262,13 +292,13 @@ func (a *Agent) Chat(userID, text string, isVoice bool, images []llm.Image) (str
 			}
 		}
 
-		a.appendHistory(userID, a.llm.FormatToolResults(results)...)
+		a.appendHistory(userID, provider.FormatToolResults(results)...)
 
 		if needsApproval {
 			p := a.tools.PendingApproval(userID)
 			reply := approvalMessage(p)
 			a.addTokens(usage.In, usage.Out)
-			logger.Done(start, usage.In, usage.Out, cacheRead, toolsUsed, estimateCost(a.llm.Model(), usage.In, usage.Out))
+			logger.Done(start, usage.In, usage.Out, cacheRead, toolsUsed, estimateCost(provider.Model(), usage.In, usage.Out))
 			logger.Nevinho(reply)
 			return reply, nil
 		}
@@ -276,7 +306,7 @@ func (a *Agent) Chat(userID, text string, isVoice bool, images []llm.Image) (str
 
 	reply := "I hit my limit on tool calls. Try breaking it into smaller tasks."
 	a.addTokens(usage.In, usage.Out)
-	logger.Done(start, usage.In, usage.Out, cacheRead, toolsUsed, estimateCost(a.llm.Model(), usage.In, usage.Out))
+	logger.Done(start, usage.In, usage.Out, cacheRead, toolsUsed, estimateCost(provider.Model(), usage.In, usage.Out))
 	logger.Nevinho(reply)
 	return reply, nil
 }

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -60,7 +60,10 @@ func Chat(configDir, version, selfDoc string) {
 			continue
 		}
 
-		response, err := a.Chat(chatUserID, text, false, nil)
+		response, err := a.Chat(agent.ChatRequest{
+			UserID: chatUserID,
+			Text:   text,
+		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			continue

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -90,11 +90,15 @@ func startScheduler(a *agent.Agent, bot *discord.Bot, configDir string) (*schedu
 	a.SetScheduleStore(store)
 	bot.SetScheduleStore(store)
 
-	runFn := func(ctx context.Context, userID, prompt string) (string, error) {
+	runFn := func(ctx context.Context, userID, prompt, model string) (string, error) {
 		// Chat manages its own per-call timeout. The ctx here is the
 		// runner's deadline, used by future agent paths that accept it.
 		_ = ctx
-		return a.Chat(userID, prompt, false, nil)
+		return a.Chat(agent.ChatRequest{
+			UserID: userID,
+			Text:   prompt,
+			Model:  model,
+		})
 	}
 
 	notifyFn := func(s schedule.Schedule, result string, err error) {

--- a/discord/commands.go
+++ b/discord/commands.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/lucasnevespereira/nevinho/agent"
 	"github.com/lucasnevespereira/nevinho/llm"
 	"github.com/lucasnevespereira/nevinho/schedule"
 )
@@ -273,7 +274,10 @@ func (b *Bot) runApproval(s *discordgo.Session, channelID, userID string) {
 	indicator := newActivityIndicator(s, channelID)
 	b.agent.SetToolCallback(userID, indicator.onEvent)
 
-	response, err := b.agent.Chat(userID, "yes", false, nil)
+	response, err := b.agent.Chat(agent.ChatRequest{
+		UserID: userID,
+		Text:   "yes",
+	})
 	b.agent.SetToolCallback(userID, nil)
 	indicator.Close()
 	stopTyping()
@@ -565,6 +569,9 @@ func formatSchedules(list []schedule.Schedule) string {
 		fmt.Fprintf(&sb, "\n%s `%s`\n", state, s.Name)
 		fmt.Fprintf(&sb, "  cron: `%s`%s\n", s.Cron, formatTzSuffix(s.Timezone))
 		fmt.Fprintf(&sb, "  next: %s\n", formatScheduleNext(s))
+		if s.Model != "" {
+			fmt.Fprintf(&sb, "  model: `%s`\n", s.Model)
+		}
 		fmt.Fprintf(&sb, "  prompt: %s\n", s.Prompt)
 		if len(s.Runs) > 0 {
 			fmt.Fprintf(&sb, "  last: %s\n", formatLastRunInline(s.Runs[0]))

--- a/discord/messages.go
+++ b/discord/messages.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/lucasnevespereira/nevinho/agent"
 	"github.com/lucasnevespereira/nevinho/llm"
 	"github.com/lucasnevespereira/nevinho/logger"
 )
@@ -122,7 +123,12 @@ func (b *Bot) onMessage(s *discordgo.Session, m *discordgo.MessageCreate) {
 	indicator := newActivityIndicator(s, m.ChannelID)
 	b.agent.SetToolCallback(m.Author.ID, indicator.onEvent)
 
-	response, err := b.agent.Chat(m.Author.ID, text, isVoice, images)
+	response, err := b.agent.Chat(agent.ChatRequest{
+		UserID:  m.Author.ID,
+		Text:    text,
+		IsVoice: isVoice,
+		Images:  images,
+	})
 	b.agent.SetToolCallback(m.Author.ID, nil)
 	indicator.Close()
 	stopTyping()

--- a/schedule/runner.go
+++ b/schedule/runner.go
@@ -10,10 +10,12 @@ import (
 	"github.com/lucasnevespereira/nevinho/logger"
 )
 
-// RunFunc executes a schedule prompt and returns the agent's reply, or an
-// error. It receives a derived context with RunTimeout and a userID
+// RunFunc executes a schedule prompt and returns the agent's reply, or
+// an error. It receives a derived context with RunTimeout and a userID
 // namespace ("scheduler:<id>") so manual chat history is not polluted.
-type RunFunc func(ctx context.Context, userID, prompt string) (string, error)
+// model is empty when the schedule does not pin one, in which case the
+// agent uses its currently selected provider.
+type RunFunc func(ctx context.Context, userID, prompt, model string) (string, error)
 
 // NotifyFunc delivers a run result to the user. The runner calls it after
 // each completion (success or error). Errors arrive with err set and a
@@ -124,7 +126,7 @@ func (r *Runner) execute(sched Schedule) {
 	defer cancel()
 
 	userID := "scheduler:" + sched.ID
-	result, err := safeRun(ctx, r.run, userID, sched.Prompt)
+	result, err := safeRun(ctx, r.run, userID, sched.Prompt, sched.Model)
 
 	log := RunLog{
 		StartedAt: ranAt,
@@ -158,11 +160,11 @@ func truncatePreview(text string, max int) string {
 
 // safeRun calls the agent and recovers from any panic so a single bad
 // scheduled prompt cannot take down the runner.
-func safeRun(ctx context.Context, run RunFunc, userID, prompt string) (result string, err error) {
+func safeRun(ctx context.Context, run RunFunc, userID, prompt, model string) (result string, err error) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			err = fmt.Errorf("scheduled run panicked: %v", rec)
 		}
 	}()
-	return run(ctx, userID, prompt)
+	return run(ctx, userID, prompt, model)
 }

--- a/schedule/schedule.go
+++ b/schedule/schedule.go
@@ -83,6 +83,10 @@ type Schedule struct {
 	// the cron expression. Empty means the server's local time.
 	Timezone string `json:"timezone,omitempty"`
 
+	// Model pins the LLM provider for this schedule's runs. Empty means
+	// the agent's currently selected model is used at run time.
+	Model string `json:"model,omitempty"`
+
 	// Runs is the inline run history. Newest first.
 	Runs []RunLog `json:"runs,omitempty"`
 }
@@ -169,11 +173,17 @@ func (s *Store) Find(key string) (Schedule, bool) {
 //
 // Pass tz as an IANA timezone name (e.g. "Europe/Paris") to evaluate
 // the cron in that location. Empty tz uses the server's local time.
-func (s *Store) Create(name, cronExpr, prompt, tz string) (Schedule, error) {
+//
+// Pass model to pin a specific LLM provider for this schedule's runs.
+// The caller is responsible for validating the name against any catalog
+// before calling Create. Empty model means the agent's selected model is
+// used at run time.
+func (s *Store) Create(name, cronExpr, prompt, tz, model string) (Schedule, error) {
 	name = trim(name)
 	cronExpr = trim(cronExpr)
 	prompt = trim(prompt)
 	tz = trim(tz)
+	model = trim(model)
 
 	if name == "" || cronExpr == "" || prompt == "" {
 		return Schedule{}, fmt.Errorf("name, cron, and prompt are required")
@@ -209,6 +219,7 @@ func (s *Store) Create(name, cronExpr, prompt, tz string) (Schedule, error) {
 		NextRun:  sched.Next(now),
 		Created:  now,
 		Timezone: tz,
+		Model:    model,
 	}
 	s.list = append(s.list, entry)
 	if err := s.save(); err != nil {

--- a/schedule/schedule_test.go
+++ b/schedule/schedule_test.go
@@ -18,7 +18,7 @@ func newTestStore(t *testing.T) *Store {
 
 func TestCreateAndList(t *testing.T) {
 	s := newTestStore(t)
-	got, err := s.Create("morning-hn", "@daily", "summarize HN", "")
+	got, err := s.Create("morning-hn", "@daily", "summarize HN", "", "")
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -38,17 +38,17 @@ func TestCreateAndList(t *testing.T) {
 
 func TestCreateRejectsDuplicateName(t *testing.T) {
 	s := newTestStore(t)
-	if _, err := s.Create("daily", "@daily", "x", ""); err != nil {
+	if _, err := s.Create("daily", "@daily", "x", "", ""); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.Create("daily", "@hourly", "y", ""); err == nil {
+	if _, err := s.Create("daily", "@hourly", "y", "", ""); err == nil {
 		t.Fatal("expected duplicate-name error")
 	}
 }
 
 func TestCreateRejectsTooFrequent(t *testing.T) {
 	s := newTestStore(t)
-	_, err := s.Create("spam", "@every 1m", "x", "")
+	_, err := s.Create("spam", "@every 1m", "x", "", "")
 	if err == nil || !strings.Contains(err.Error(), "minimum") {
 		t.Errorf("expected min-interval error, got %v", err)
 	}
@@ -56,7 +56,7 @@ func TestCreateRejectsTooFrequent(t *testing.T) {
 
 func TestCreateWithTimezone(t *testing.T) {
 	s := newTestStore(t)
-	got, err := s.Create("paris-morning", "0 9 * * *", "summarize", "Europe/Paris")
+	got, err := s.Create("paris-morning", "0 9 * * *", "summarize", "Europe/Paris", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,29 +75,60 @@ func TestCreateWithTimezone(t *testing.T) {
 	}
 }
 
+func TestCreateWithModel(t *testing.T) {
+	s := newTestStore(t)
+	got, err := s.Create("haiku-news", "@daily", "summarize", "", "claude-haiku-4-5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Model != "claude-haiku-4-5" {
+		t.Errorf("Model = %q, want claude-haiku-4-5", got.Model)
+	}
+
+	loaded, err := LoadStore(s.dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got2, _ := loaded.Find("haiku-news")
+	if got2.Model != "claude-haiku-4-5" {
+		t.Errorf("after reload Model = %q, want claude-haiku-4-5", got2.Model)
+	}
+}
+
+func TestCreateWithoutModelLeavesItEmpty(t *testing.T) {
+	s := newTestStore(t)
+	got, err := s.Create("default-model", "@daily", "summarize", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Model != "" {
+		t.Errorf("Model = %q, want empty (uses agent default)", got.Model)
+	}
+}
+
 func TestCreateRejectsInvalidTimezone(t *testing.T) {
 	s := newTestStore(t)
-	if _, err := s.Create("bad-tz", "0 9 * * *", "x", "Europe/Pariss"); err == nil {
+	if _, err := s.Create("bad-tz", "0 9 * * *", "x", "Europe/Pariss", ""); err == nil {
 		t.Error("expected invalid timezone to error")
 	}
 }
 
 func TestCreateRejectsBadCron(t *testing.T) {
 	s := newTestStore(t)
-	if _, err := s.Create("bad", "every monday", "x", ""); err == nil {
+	if _, err := s.Create("bad", "every monday", "x", "", ""); err == nil {
 		t.Fatal("expected parse error")
 	}
 }
 
 func TestCreateRejectsMissingFields(t *testing.T) {
 	s := newTestStore(t)
-	if _, err := s.Create("", "@daily", "x", ""); err == nil {
+	if _, err := s.Create("", "@daily", "x", "", ""); err == nil {
 		t.Error("missing name should error")
 	}
-	if _, err := s.Create("a", "", "x", ""); err == nil {
+	if _, err := s.Create("a", "", "x", "", ""); err == nil {
 		t.Error("missing cron should error")
 	}
-	if _, err := s.Create("a", "@daily", "", ""); err == nil {
+	if _, err := s.Create("a", "@daily", "", "", ""); err == nil {
 		t.Error("missing prompt should error")
 	}
 }
@@ -106,18 +137,18 @@ func TestCreateEnforcesMaxSchedules(t *testing.T) {
 	s := newTestStore(t)
 	for i := range MaxSchedules {
 		name := "s" + string(rune('A'+i))
-		if _, err := s.Create(name, "@daily", "x", ""); err != nil {
+		if _, err := s.Create(name, "@daily", "x", "", ""); err != nil {
 			t.Fatalf("Create %s: %v", name, err)
 		}
 	}
-	if _, err := s.Create("overflow", "@daily", "x", ""); err == nil {
+	if _, err := s.Create("overflow", "@daily", "x", "", ""); err == nil {
 		t.Error("expected max-schedules error")
 	}
 }
 
 func TestDelete(t *testing.T) {
 	s := newTestStore(t)
-	if _, err := s.Create("doomed", "@daily", "x", ""); err != nil {
+	if _, err := s.Create("doomed", "@daily", "x", "", ""); err != nil {
 		t.Fatal(err)
 	}
 	ok, err := s.Delete("doomed")
@@ -145,7 +176,7 @@ func TestDeleteMissing(t *testing.T) {
 
 func TestSetEnabledTogglesAndRefreshesNextRun(t *testing.T) {
 	s := newTestStore(t)
-	created, err := s.Create("toggleable", "@daily", "x", "")
+	created, err := s.Create("toggleable", "@daily", "x", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +208,7 @@ func TestPersistsAcrossLoads(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s1.Create("persist-me", "@daily", "x", ""); err != nil {
+	if _, err := s1.Create("persist-me", "@daily", "x", "", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -193,7 +224,7 @@ func TestPersistsAcrossLoads(t *testing.T) {
 
 func TestDueSchedulesSkipsMissedRunsAfterDowntime(t *testing.T) {
 	s := newTestStore(t)
-	created, err := s.Create("hourly", "@every 1h", "x", "")
+	created, err := s.Create("hourly", "@every 1h", "x", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +253,7 @@ func TestDueSchedulesSkipsMissedRunsAfterDowntime(t *testing.T) {
 
 func TestRecordRunAppendsAndCaps(t *testing.T) {
 	s := newTestStore(t)
-	created, err := s.Create("trace", "@daily", "x", "")
+	created, err := s.Create("trace", "@daily", "x", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -251,7 +282,7 @@ func TestRecordRunAppendsAndCaps(t *testing.T) {
 
 func TestRecordRunUpdatesNextAndLast(t *testing.T) {
 	s := newTestStore(t)
-	created, err := s.Create("ticker", "@every 1h", "x", "")
+	created, err := s.Create("ticker", "@every 1h", "x", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -305,8 +336,8 @@ func TestPrependCappedTrims(t *testing.T) {
 
 func TestDueSchedulesReturnsOnlyEnabledAndPastDue(t *testing.T) {
 	s := newTestStore(t)
-	a, _ := s.Create("a", "@daily", "x", "")
-	_, _ = s.Create("b", "@daily", "x", "")
+	a, _ := s.Create("a", "@daily", "x", "", "")
+	_, _ = s.Create("b", "@daily", "x", "", "")
 	_, _ = s.SetEnabled("b", false)
 
 	// Force a's NextRun to the past.

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -247,6 +247,7 @@ Translate the user's natural language into a cron expression yourself. Do not as
 Schedules run without an interactive approval prompt, so refuse to create schedules whose prompts would normally need approval (destructive bash, file writes outside approved paths). Suggest a safer prompt instead.
 Cron accepts standard 5-field expressions ("0 9 * * *"), descriptors (@daily, @hourly, @weekly), and durations (@every 30m, @every 6h). Minimum interval is 5 minutes. Maximum 10 schedules total.
 Timezones: pass an IANA name (e.g. "Europe/Paris", "America/New_York") via the timezone argument when the user mentions a city or zone. The cron expression is then evaluated in that timezone. Without a timezone, the server's local time is used.
+Models: pass a model name (e.g. "claude-haiku-4-5", "gpt-4o-mini") via the model argument to pin a cheaper model for repetitive runs ("use Haiku, it's enough"). Without a model, the agent's currently selected model is used at run time.
 Actions:
 - list: returns every schedule with its cron, next run, and current state. Default action when "action" is omitted.
 - create: requires name, cron, and prompt. Returns the new entry with its first NextRun.
@@ -255,7 +256,7 @@ Actions:
 - resume: requires name. Re-enables a paused schedule and recomputes NextRun.
 - logs: requires name. Returns the last 10 runs (timestamp, duration, status, preview or error).
 Output: human readable text. Errors are prefixed with "failed: " or "invalid input:".`,
-			Schema: `{"type":"object","properties":{"action":{"type":"string","enum":["list","create","delete","pause","resume","logs"],"description":"Action to perform"},"name":{"type":"string","description":"Unique schedule name. Required for create, delete, pause, resume, and logs."},"cron":{"type":"string","description":"Cron expression. Required for create. Examples: \"0 9 * * *\", \"@daily\", \"@every 30m\"."},"prompt":{"type":"string","description":"What nevinho should run on each fire. Required for create."},"timezone":{"type":"string","description":"Optional IANA timezone (e.g. \"Europe/Paris\"). When set, the cron is evaluated in this zone."}},"required":["action"]}`,
+			Schema: `{"type":"object","properties":{"action":{"type":"string","enum":["list","create","delete","pause","resume","logs"],"description":"Action to perform"},"name":{"type":"string","description":"Unique schedule name. Required for create, delete, pause, resume, and logs."},"cron":{"type":"string","description":"Cron expression. Required for create. Examples: \"0 9 * * *\", \"@daily\", \"@every 30m\"."},"prompt":{"type":"string","description":"What nevinho should run on each fire. Required for create."},"timezone":{"type":"string","description":"Optional IANA timezone (e.g. \"Europe/Paris\"). When set, the cron is evaluated in this zone."},"model":{"type":"string","description":"Optional model name to pin for this schedule (e.g. \"claude-haiku-4-5\"). Empty uses the agent's current model."}},"required":["action"]}`,
 		},
 	}
 }

--- a/tools/schedule.go
+++ b/tools/schedule.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lucasnevespereira/nevinho/llm"
 	"github.com/lucasnevespereira/nevinho/schedule"
 )
 
@@ -15,6 +16,7 @@ type scheduleInput struct {
 	Cron     string `json:"cron"`
 	Prompt   string `json:"prompt"`
 	Timezone string `json:"timezone"`
+	Model    string `json:"model"`
 }
 
 func (r *Registry) scheduleTool(input json.RawMessage) string {
@@ -35,7 +37,10 @@ func (r *Registry) scheduleTool(input json.RawMessage) string {
 	case "", "list":
 		return formatScheduleList(store.All())
 	case "create":
-		s, err := store.Create(in.Name, in.Cron, in.Prompt, in.Timezone)
+		if in.Model != "" && !llm.IsKnownModel(in.Model) {
+			return fmt.Sprintf("failed: unknown model %q. Use a model from the catalog or omit to follow the agent's current selection.", in.Model)
+		}
+		s, err := store.Create(in.Name, in.Cron, in.Prompt, in.Timezone, in.Model)
 		if err != nil {
 			return "failed: " + err.Error()
 		}
@@ -88,6 +93,9 @@ func formatScheduleList(list []schedule.Schedule) string {
 			formatScheduledTime(s),
 			truncate(s.Prompt, 80),
 		)
+		if s.Model != "" {
+			fmt.Fprintf(&sb, "  model: %s\n", s.Model)
+		}
 		if last := lastRun(s); last != nil {
 			fmt.Fprintf(&sb, "  last: %s\n", formatLastRun(*last))
 		}


### PR DESCRIPTION
Builds on top of #49 (timezones). Once #49 merges, rebase or update base.

## What

Schedules can pin a specific LLM model. The agent's interactive model stays untouched, the schedule uses the override only at fire time.

## Why

Most schedules can run on Haiku ("summarize HN" doesn't need Sonnet). Without per-schedule pinning, all scheduled runs ride whatever the operator currently chats with. Pinning lets the operator stay on Sonnet for chat while paying Haiku rates for cheap recurring jobs.

## Design

- New \`agent.ChatRequest\` struct collects the inputs of one chat turn. \`Chat(req ChatRequest)\` replaces the four-positional signature. Future per-call options (max tokens, etc) drop into the struct without breaking callers again.
- \`ChatRequest.Model\` overrides the agent's provider for that call only. \`a.llm\` is never mutated. The override resolves through \`llm.Resolve\` with the agent's existing provider config.
- \`Schedule.Model\` field stores the pinned name (optional, validated at create time against \`llm.IsKnownModel\`).
- \`schedule.RunFunc\` gains a model parameter. The runner passes \`sched.Model\` so the override is per-schedule, not global.
- Discord and the agent tool show the pinned model only when set, no annotation otherwise.

## Tests

- \`TestCreateWithModel\` covers persistence round-trip.
- \`TestCreateWithoutModelLeavesItEmpty\` confirms the empty default.
- \`TestResolveAllowsKnownOpenAI\` and \`TestResolveAllowsKnownAnthropic\` (existing) cover the resolve path the override uses.
- 241 tests pass.

## UX

Natural language entry:
> "every morning summarize HN, use Haiku, it's enough"

Agent calls \`schedule_create({..., model: "claude-haiku-4-5"})\`. Model validated and stored.

\`/schedules\`:
\`\`\`
▶ morning-hn
  cron: \`0 9 * * *\` (Europe/Paris)
  next: Sat 2026-05-11 09:00 CEST
  model: \`claude-haiku-4-5\`
  prompt: summarize HN
\`\`\`