### PR TITLE
Claim NextRun before running to prevent double fire

### DIFF
--- a/discord/commands.go
+++ b/discord/commands.go
@@ -581,19 +581,13 @@ func formatTzSuffix(tz string) string {
 	return " (" + tz + ")"
 }
 
-// formatScheduleNext renders NextRun in the schedule's own timezone when set,
-// so the operator reads the time in the zone they configured.
+// formatScheduleNext renders NextRun in the schedule's own timezone for
+// the Discord listing.
 func formatScheduleNext(s schedule.Schedule) string {
 	if s.NextRun.IsZero() {
 		return "never"
 	}
-	t := s.NextRun
-	if s.Timezone != "" {
-		if loc, err := time.LoadLocation(s.Timezone); err == nil {
-			t = t.In(loc)
-		}
-	}
-	return t.Format("Mon 2006-01-02 15:04 MST")
+	return s.NextRunIn().Format("Mon 2006-01-02 15:04 MST")
 }
 
 func formatScheduleLogs(s schedule.Schedule) string {

--- a/schedule/runner.go
+++ b/schedule/runner.go
@@ -120,6 +120,15 @@ func (r *Runner) execute(sched Schedule) {
 	logger.Info(fmt.Sprintf("schedule: running %s", sched.Name))
 	ranAt := time.Now()
 
+	// Advance NextRun and persist BEFORE running. If the disk write fails,
+	// we abort the run so the next tick retries cleanly. If it succeeds
+	// and the run later panics or crashes, NextRun has already moved so
+	// the schedule will not double fire.
+	if _, err := r.store.claimNextRun(sched.ID, ranAt); err != nil {
+		logger.Err(fmt.Errorf("schedule %s: claim next run: %w", sched.Name, err))
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(r.ctx, RunTimeout)
 	defer cancel()
 
@@ -137,8 +146,10 @@ func (r *Runner) execute(sched Schedule) {
 		log.Preview = truncatePreview(result, PreviewMaxLen)
 	}
 
-	if updateErr := r.store.recordRun(sched.ID, log); updateErr != nil {
-		logger.Err(fmt.Errorf("schedule %s: persist run: %w", sched.Name, updateErr))
+	if logErr := r.store.appendRunLog(sched.ID, log); logErr != nil {
+		// Log entry lost. The run already happened and will not double
+		// fire because NextRun was advanced before the run.
+		logger.Err(fmt.Errorf("schedule %s: append log: %w", sched.Name, logErr))
 	}
 
 	if r.notify != nil {

--- a/schedule/schedule.go
+++ b/schedule/schedule.go
@@ -75,8 +75,8 @@ type Schedule struct {
 	Cron    string    `json:"cron"`
 	Prompt  string    `json:"prompt"`
 	Enabled bool      `json:"enabled"`
-	LastRun time.Time `json:"last_run,omitempty"`
-	NextRun time.Time `json:"next_run,omitempty"`
+	LastRun time.Time `json:"last_run"`
+	NextRun time.Time `json:"next_run"`
 	Created time.Time `json:"created"`
 
 	// Timezone is the IANA name (e.g. "Europe/Paris") used to evaluate
@@ -85,6 +85,19 @@ type Schedule struct {
 
 	// Runs is the inline run history. Newest first.
 	Runs []RunLog `json:"runs,omitempty"`
+}
+
+// NextRunIn returns NextRun rendered in the schedule's timezone when set,
+// falling back to the server's local time. Used by display layers so the
+// operator reads the next fire in the zone they configured.
+func (s Schedule) NextRunIn() time.Time {
+	if s.Timezone == "" || s.NextRun.IsZero() {
+		return s.NextRun
+	}
+	if loc, err := time.LoadLocation(s.Timezone); err == nil {
+		return s.NextRun.In(loc)
+	}
+	return s.NextRun
 }
 
 // Store loads, mutates, and persists schedules atomically. Safe for
@@ -255,11 +268,16 @@ func (s *Store) SetEnabled(key string, enabled bool) (Schedule, error) {
 	return Schedule{}, fmt.Errorf("schedule %q not found", key)
 }
 
-// recordRun appends a RunLog (capped at MaxRunsKept), updates LastRun
-// and NextRun, then saves. On save failure the in-memory state is
-// rolled back so the next tick retries the run instead of silently
-// skipping it.
-func (s *Store) recordRun(id string, log RunLog) error {
+// claimNextRun advances LastRun and NextRun for the given schedule and
+// persists the change. The runner calls this BEFORE firing the prompt so
+// that, if the disk write fails, the run does not happen and the next
+// tick retries cleanly. If the write succeeds and the run later fails or
+// crashes, the schedule still does not double fire because NextRun has
+// already advanced.
+//
+// Returns the schedule snapshot (with the new NextRun) for the runner to
+// use, or an error if persistence fails.
+func (s *Store) claimNextRun(id string, ranAt time.Time) (Schedule, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for i, sc := range s.list {
@@ -268,22 +286,39 @@ func (s *Store) recordRun(id string, log RunLog) error {
 		}
 		parsed, err := parseCronInTimezone(sc.Cron, sc.Timezone)
 		if err != nil {
-			return err
+			return Schedule{}, err
 		}
 
-		oldRuns := sc.Runs
-		oldLastRun := sc.LastRun
-		oldNextRun := sc.NextRun
-
-		sc.Runs = prependCapped(sc.Runs, log, MaxRunsKept)
-		sc.LastRun = log.StartedAt
-		sc.NextRun = parsed.Next(log.StartedAt)
+		oldLast, oldNext := sc.LastRun, sc.NextRun
+		sc.LastRun = ranAt
+		sc.NextRun = parsed.Next(ranAt)
 		s.list[i] = sc
 
 		if err := s.save(); err != nil {
+			s.list[i].LastRun = oldLast
+			s.list[i].NextRun = oldNext
+			return Schedule{}, err
+		}
+		return sc, nil
+	}
+	return Schedule{}, fmt.Errorf("schedule %q not found", id)
+}
+
+// appendRunLog stores the outcome of a completed run. Called AFTER the
+// run, after claimNextRun has already advanced NextRun. A failure here
+// only loses the log entry, the schedule does not double fire.
+func (s *Store) appendRunLog(id string, log RunLog) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, sc := range s.list {
+		if sc.ID != id {
+			continue
+		}
+		oldRuns := sc.Runs
+		sc.Runs = prependCapped(sc.Runs, log, MaxRunsKept)
+		s.list[i] = sc
+		if err := s.save(); err != nil {
 			s.list[i].Runs = oldRuns
-			s.list[i].LastRun = oldLastRun
-			s.list[i].NextRun = oldNextRun
 			return err
 		}
 		return nil

--- a/schedule/schedule_test.go
+++ b/schedule/schedule_test.go
@@ -220,7 +220,7 @@ func TestDueSchedulesSkipsMissedRunsAfterDowntime(t *testing.T) {
 	}
 }
 
-func TestRecordRunAppendsAndCaps(t *testing.T) {
+func TestAppendRunLogCapsAt10(t *testing.T) {
 	s := newTestStore(t)
 	created, err := s.Create("trace", "@daily", "x", "")
 	if err != nil {
@@ -234,7 +234,7 @@ func TestRecordRunAppendsAndCaps(t *testing.T) {
 			Success:   true,
 			Preview:   "run " + string(rune('a'+i)),
 		}
-		if err := s.recordRun(created.ID, log); err != nil {
+		if err := s.appendRunLog(created.ID, log); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -249,7 +249,7 @@ func TestRecordRunAppendsAndCaps(t *testing.T) {
 	}
 }
 
-func TestRecordRunUpdatesNextAndLast(t *testing.T) {
+func TestClaimNextRunAdvancesBeforeRun(t *testing.T) {
 	s := newTestStore(t)
 	created, err := s.Create("ticker", "@every 1h", "x", "")
 	if err != nil {
@@ -257,22 +257,49 @@ func TestRecordRunUpdatesNextAndLast(t *testing.T) {
 	}
 
 	ranAt := created.NextRun.Add(2 * time.Minute)
+	claimed, err := s.claimNextRun(created.ID, ranAt)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	if err := s.recordRun(created.ID, RunLog{
-		StartedAt: ranAt,
+	if !claimed.LastRun.Equal(ranAt) {
+		t.Errorf("claimed LastRun = %s, want %s", claimed.LastRun, ranAt)
+	}
+	wantNext := ranAt.Add(time.Hour)
+	if !claimed.NextRun.Equal(wantNext) {
+		t.Errorf("claimed NextRun = %s, want %s (ranAt + 1h)", claimed.NextRun, wantNext)
+	}
+
+	stored, _ := s.Find("ticker")
+	if !stored.NextRun.Equal(wantNext) {
+		t.Errorf("stored NextRun = %s, want %s (persisted)", stored.NextRun, wantNext)
+	}
+}
+
+func TestAppendRunLogDoesNotAffectNextRun(t *testing.T) {
+	s := newTestStore(t)
+	created, err := s.Create("ticker", "@every 1h", "x", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	beforeNext := created.NextRun
+
+	err = s.appendRunLog(created.ID, RunLog{
+		StartedAt: time.Now(),
 		Duration:  500 * time.Millisecond,
 		Success:   true,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 
 	got, _ := s.Find("ticker")
-	if !got.LastRun.Equal(ranAt) {
-		t.Errorf("LastRun = %s, want %s", got.LastRun, ranAt)
+	if !got.NextRun.Equal(beforeNext) {
+		t.Errorf("appendRunLog should not move NextRun, got %s, want %s", got.NextRun, beforeNext)
 	}
-	wantNext := ranAt.Add(time.Hour)
-	if !got.NextRun.Equal(wantNext) {
-		t.Errorf("NextRun = %s, want %s (ranAt + 1h)", got.NextRun, wantNext)
+	if len(got.Runs) != 1 {
+		t.Errorf("Runs len = %d, want 1", len(got.Runs))
 	}
 }
 

--- a/tools/schedule.go
+++ b/tools/schedule.go
@@ -95,20 +95,13 @@ func formatScheduleList(list []schedule.Schedule) string {
 	return strings.TrimRight(sb.String(), "\n")
 }
 
-// formatScheduledTime renders the schedule's NextRun in its own timezone
-// when one is set, falling back to server local time. Helps the operator
-// read the next fire in the time zone they configured the schedule for.
+// formatScheduledTime renders NextRun in the schedule's timezone for the
+// agent's text reply.
 func formatScheduledTime(s schedule.Schedule) string {
 	if s.NextRun.IsZero() {
 		return "never"
 	}
-	t := s.NextRun
-	if s.Timezone != "" {
-		if loc, err := time.LoadLocation(s.Timezone); err == nil {
-			t = t.In(loc)
-		}
-	}
-	return t.Format("2006-01-02 15:04 MST")
+	return s.NextRunIn().Format("2006-01-02 15:04 MST")
 }
 
 // tzSuffix renders " (Europe/Paris)" when set, empty otherwise.


### PR DESCRIPTION
## What

Fixes a real correctness bug in the scheduler and trims a small bit of duplication along the way.

## The bug

\`recordRun\` used to do everything at the end of a run (append log, advance NextRun, save). On save failure it rolled back NextRun "so the next tick retries the run."

That's wrong. The run already happened. The notify DM already went out. The agent already burned tokens. Maybe the run sent an email or hit a webhook. **Rolling back NextRun guaranteed the same run would fire again on the next tick.**

## The fix

Split the persistence into two steps:

1. **\`claimNextRun(id, ranAt)\`** runs BEFORE the prompt. Advances LastRun and NextRun, persists. If the disk write fails, the runner aborts the run and the next tick retries cleanly. If the run later panics or crashes after this call, NextRun has already moved so the schedule will not double fire.

2. **\`appendRunLog(id, log)\`** runs AFTER the prompt. Stores the outcome separately. If this disk write fails the log entry is lost, but the schedule still does not double fire because NextRun was advanced earlier.

The two writes touch the same encrypted store but the file is tiny (max 10 schedules with at most 10 runs each).

## Other small fixes bundled

- **Drop misleading \`omitempty\` on \`time.Time\` fields**. \`encoding/json\` does not honor it for struct values, so the tag was a lie. The fields always serialize.
- **\`Schedule.NextRunIn()\` method** centralizes the timezone conversion. \`formatScheduleNext\` (Discord) and \`formatScheduledTime\` (agent reply) both use it now. Display format strings stay at the call site since they differ by context.

## Tests

- \`TestClaimNextRunAdvancesBeforeRun\` covers the new pre-run advance and persistence.
- \`TestAppendRunLogCapsAt10\` is the renamed log-append test.
- \`TestAppendRunLogDoesNotAffectNextRun\` confirms the separation: appending a log does not move NextRun.
- All existing tests still pass. 240 tests total.