### PR TITLE
feat(llm): add groq and openrouter providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # nevinho
 
 A minimal personal AI harness that runs in your Discord DMs.
-Supports Anthropic, OpenAI, and Ollama.
+Supports Anthropic, OpenAI, Groq, OpenRouter, and Ollama.
 Comes with tools for bash, code search, web search, and file management.
 
 ## Install
@@ -57,13 +57,19 @@ See [setup.md](setup.md) for Discord bot creation steps.
 
 Configure one or more LLM backends during setup:
 
-| Provider  | Env var               | Default model    |
-| --------- | --------------------- | ---------------- |
-| Anthropic | `ANTHROPIC_API_KEY`   | claude-haiku-4-5 |
-| OpenAI    | `OPENAI_API_KEY`      | gpt-4o-mini      |
-| Ollama    | `OLLAMA_MODEL=llama3` | any local model  |
+| Provider   | Env var                  | Default model                                          | Get a key                                       |
+| ---------- | ------------------------ | ------------------------------------------------------ | ----------------------------------------------- |
+| Anthropic  | `ANTHROPIC_API_KEY`      | claude-haiku-4-5                                       | https://console.anthropic.com                   |
+| OpenAI     | `OPENAI_API_KEY`         | gpt-4o-mini                                            | https://platform.openai.com/api-keys            |
+| Groq       | `GROQ_API_KEY`           | groq:llama-3.3-70b-versatile                           | https://console.groq.com/keys                   |
+| OpenRouter | `OPENROUTER_API_KEY`     | openrouter:meta-llama/llama-3.3-70b-instruct:free      | https://openrouter.ai/keys                      |
+| Ollama     | `OLLAMA_MODEL=llama3`    | any local model                                        | run locally                                     |
 
-On startup, nevinho uses your last selected model. If none is saved, it picks the first available: Ollama > Anthropic > OpenAI.
+Groq and OpenRouter both offer a free tier with daily request quotas. Useful for testing or low volume personal use without burning API credits.
+
+Groq model names are prefixed with `groq:` (e.g. `groq:llama-3.3-70b-versatile`). OpenRouter routes are prefixed with `openrouter:` (e.g. `openrouter:meta-llama/llama-3.3-70b-instruct:free`). Both providers accept any model name in their catalog after the prefix.
+
+On startup, nevinho uses your last selected model. If none is saved, it picks the first available: Anthropic > OpenAI > Groq > OpenRouter > Ollama.
 
 Switch models at runtime with `/model` (dropdown selector) or `/model <name>`.
 
@@ -161,7 +167,7 @@ upgrade.go   self-update from GitHub releases
 agent/       chat loop, tool orchestration, approval flow
 config/      encrypted configuration management
 crypto/      shared AES-256-GCM encryption
-llm/         provider interface (Anthropic, OpenAI, Ollama)
+llm/         provider interface (Anthropic, OpenAI, Groq, OpenRouter, Ollama)
 memory/      harness-level preference learning
 tools/       bash, grep, find, web search, file I/O
 voice/       local Whisper transcription for voice messages

--- a/config/config.go
+++ b/config/config.go
@@ -18,29 +18,33 @@ type Config struct {
 	key      [32]byte
 	filePath string
 
-	DiscordBotToken string `json:"discord_bot_token"`
-	DiscordOwnerID  string `json:"discord_owner_id"`
-	AnthropicAPIKey string `json:"anthropic_api_key"`
-	OpenAIAPIKey    string `json:"openai_api_key"`
-	OllamaModel     string `json:"ollama_model"`
-	TavilyAPIKey    string `json:"tavily_api_key"`
-	Model           string `json:"model"`
-	Caveman         string `json:"caveman"`
-	Elephant        string `json:"elephant"`
+	DiscordBotToken  string `json:"discord_bot_token"`
+	DiscordOwnerID   string `json:"discord_owner_id"`
+	AnthropicAPIKey  string `json:"anthropic_api_key"`
+	OpenAIAPIKey     string `json:"openai_api_key"`
+	GroqAPIKey       string `json:"groq_api_key"`
+	OpenRouterAPIKey string `json:"openrouter_api_key"`
+	OllamaModel      string `json:"ollama_model"`
+	TavilyAPIKey     string `json:"tavily_api_key"`
+	Model            string `json:"model"`
+	Caveman          string `json:"caveman"`
+	Elephant         string `json:"elephant"`
 }
 
 // keymap maps user-facing key names to struct field pointers.
 func (c *Config) keymap() map[string]*string {
 	return map[string]*string{
-		"DISCORD_BOT_TOKEN": &c.DiscordBotToken,
-		"DISCORD_OWNER_ID":  &c.DiscordOwnerID,
-		"ANTHROPIC_API_KEY": &c.AnthropicAPIKey,
-		"OPENAI_API_KEY":    &c.OpenAIAPIKey,
-		"OLLAMA_MODEL":      &c.OllamaModel,
-		"TAVILY_API_KEY":    &c.TavilyAPIKey,
-		"MODEL":             &c.Model,
-		"CAVEMAN":           &c.Caveman,
-		"ELEPHANT":          &c.Elephant,
+		"DISCORD_BOT_TOKEN":  &c.DiscordBotToken,
+		"DISCORD_OWNER_ID":   &c.DiscordOwnerID,
+		"ANTHROPIC_API_KEY":  &c.AnthropicAPIKey,
+		"OPENAI_API_KEY":     &c.OpenAIAPIKey,
+		"GROQ_API_KEY":       &c.GroqAPIKey,
+		"OPENROUTER_API_KEY": &c.OpenRouterAPIKey,
+		"OLLAMA_MODEL":       &c.OllamaModel,
+		"TAVILY_API_KEY":     &c.TavilyAPIKey,
+		"MODEL":              &c.Model,
+		"CAVEMAN":            &c.Caveman,
+		"ELEPHANT":           &c.Elephant,
 	}
 }
 
@@ -193,17 +197,21 @@ Examples:
 }
 
 type ProviderConfig struct {
-	AnthropicKey string
-	OpenAIKey    string
-	OllamaURL    string
+	AnthropicKey  string
+	OpenAIKey     string
+	GroqKey       string
+	OpenRouterKey string
+	OllamaURL     string
 }
 
 func (c *Config) ProviderConfig() ProviderConfig {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	pc := ProviderConfig{
-		AnthropicKey: c.AnthropicAPIKey,
-		OpenAIKey:    c.OpenAIAPIKey,
+		AnthropicKey:  c.AnthropicAPIKey,
+		OpenAIKey:     c.OpenAIAPIKey,
+		GroqKey:       c.GroqAPIKey,
+		OpenRouterKey: c.OpenRouterAPIKey,
 	}
 	if c.OllamaModel != "" {
 		pc.OllamaURL = "http://localhost:11434"

--- a/config/setup.go
+++ b/config/setup.go
@@ -59,20 +59,24 @@ func RunSetup(configDir string) error {
 
 	// LLM providers
 	fmt.Println()
-	fmt.Println("LLM providers")
+	fmt.Println("LLM providers (configure at least one)")
 	cfg.AnthropicAPIKey = prompt("Anthropic API key", cfg.AnthropicAPIKey)
 	cfg.OpenAIAPIKey = prompt("OpenAI API key", cfg.OpenAIAPIKey)
+	cfg.GroqAPIKey = prompt("Groq API key", cfg.GroqAPIKey)
+	cfg.OpenRouterAPIKey = prompt("OpenRouter API key", cfg.OpenRouterAPIKey)
 	cfg.OllamaModel = prompt("Ollama model (e.g. llama3)", cfg.OllamaModel)
 
-	// Warn if no provider
-	if cfg.AnthropicAPIKey == "" && cfg.OpenAIAPIKey == "" && cfg.OllamaModel == "" {
+	if cfg.AnthropicAPIKey == "" && cfg.OpenAIAPIKey == "" && cfg.OllamaModel == "" &&
+		cfg.GroqAPIKey == "" && cfg.OpenRouterAPIKey == "" {
 		fmt.Println()
 		fmt.Println("  Warning: no LLM provider configured. nevinho needs at least one.")
+		fmt.Println("  See README for signup URLs.")
 	}
 
 	// Default model. Suggest one based on the first configured provider so
 	// reinstall does not carry over a stale or invalid saved name.
-	if cfg.AnthropicAPIKey != "" || cfg.OpenAIAPIKey != "" || cfg.OllamaModel != "" {
+	if cfg.AnthropicAPIKey != "" || cfg.OpenAIAPIKey != "" || cfg.OllamaModel != "" ||
+		cfg.GroqAPIKey != "" || cfg.OpenRouterAPIKey != "" {
 		fmt.Println()
 		fmt.Println("Default model")
 		suggested := cfg.Model
@@ -110,6 +114,8 @@ func RunSetup(configDir string) error {
 	printStatus("  Discord", cfg.DiscordBotToken != "" && cfg.DiscordOwnerID != "")
 	printStatus("  Anthropic", cfg.AnthropicAPIKey != "")
 	printStatus("  OpenAI", cfg.OpenAIAPIKey != "")
+	printStatus("  Groq", cfg.GroqAPIKey != "")
+	printStatus("  OpenRouter", cfg.OpenRouterAPIKey != "")
 	printStatus("  Ollama", cfg.OllamaModel != "")
 	printStatus("  Tavily Search", cfg.TavilyAPIKey != "")
 	printStatus("  Voice", voice.IsAvailable(whisperDir))
@@ -124,14 +130,19 @@ func RunSetup(configDir string) error {
 }
 
 // suggestDefaultModel picks a sensible model name from the providers the
-// user just configured. Anthropic is preferred for cost and quality on the
-// default tier, then OpenAI, then whatever Ollama model was named.
+// user just configured. Free providers come first when no paid key is
+// set so the bot starts on a no cost path. Order beyond that is
+// preference for general quality at a reasonable price.
 func suggestDefaultModel(cfg *Config) string {
 	switch {
 	case cfg.AnthropicAPIKey != "":
 		return "claude-haiku-4-5"
 	case cfg.OpenAIAPIKey != "":
 		return "gpt-4o-mini"
+	case cfg.GroqAPIKey != "":
+		return "groq:llama-3.3-70b-versatile"
+	case cfg.OpenRouterAPIKey != "":
+		return "openrouter:meta-llama/llama-3.3-70b-instruct:free"
 	case cfg.OllamaModel != "":
 		return cfg.OllamaModel
 	}

--- a/discord/commands.go
+++ b/discord/commands.go
@@ -341,6 +341,16 @@ func (b *Bot) modelOptions() []discordgo.SelectMenuOption {
 			options = append(options, modelOption(name, current))
 		}
 	}
+	if pc.GroqKey != "" {
+		for _, name := range llm.KnownModels["groq"] {
+			options = append(options, modelOption(name, current))
+		}
+	}
+	if pc.OpenRouterKey != "" {
+		for _, name := range llm.KnownModels["openrouter"] {
+			options = append(options, modelOption(name, current))
+		}
+	}
 	return options
 }
 
@@ -385,6 +395,20 @@ func (b *Bot) modelStatus() string {
 	if pc.OpenAIKey != "" {
 		sb.WriteString("**OpenAI**\n")
 		for _, m := range llm.KnownModels["openai"] {
+			fmt.Fprintf(&sb, "• `%s`%s\n", m, visionTag(m))
+		}
+		sb.WriteString("\n")
+	}
+	if pc.GroqKey != "" {
+		sb.WriteString("**Groq**\n")
+		for _, m := range llm.KnownModels["groq"] {
+			fmt.Fprintf(&sb, "• `%s`%s\n", m, visionTag(m))
+		}
+		sb.WriteString("\n")
+	}
+	if pc.OpenRouterKey != "" {
+		sb.WriteString("**OpenRouter**\n")
+		for _, m := range llm.KnownModels["openrouter"] {
 			fmt.Fprintf(&sb, "• `%s`%s\n", m, visionTag(m))
 		}
 		sb.WriteString("\n")

--- a/llm/image.go
+++ b/llm/image.go
@@ -25,7 +25,7 @@ func ModelSupportsVision(name string) bool {
 		return true
 	}
 	lower := strings.ToLower(name)
-	for _, marker := range []string{"llava", "vision", "qwen2-vl", "bakllava", "moondream"} {
+	for _, marker := range []string{"llava", "vision", "qwen2-vl", "bakllava", "moondream", "gemini"} {
 		if strings.Contains(lower, marker) {
 			return true
 		}

--- a/llm/provider.go
+++ b/llm/provider.go
@@ -98,14 +98,19 @@ var KnownModels = map[string][]string{
 		"groq:gemma2-9b-it",
 		"groq:llama-3.2-90b-vision-preview",
 	},
-	// OpenRouter routes named with a ":free" suffix run on free tier
-	// quotas (~200 req/day at writing). Curated list of useful free
-	// routes. Users can also pass any other openrouter:<route> name.
+	// OpenRouter is a router across many providers. Routes ending in
+	// ":free" run on free tier quotas (~200 req/day at writing). Routes
+	// without ":free" are paid per token. Curated list mixes both. Users
+	// can also pass any other openrouter:<route> name.
 	"openrouter": {
-		"openrouter:meta-llama/llama-3.3-70b-instruct:free",
-		"openrouter:google/gemini-2.5-flash-exp:free",
-		"openrouter:qwen/qwen-2.5-72b-instruct:free",
-		"openrouter:nousresearch/hermes-3-llama-3.1-405b:free",
+		"openrouter:nvidia/nemotron-3-super-120b-a12b:free",
+		"openrouter:openai/gpt-oss-120b:free",
+		"openrouter:openai/gpt-oss-20b:free",
+		"openrouter:inclusionai/ring-2.6-1t:free",
+		"openrouter:z-ai/glm-4.5-air:free",
+		"openrouter:minimax/minimax-m2.5:free",
+		"openrouter:google/gemma-4-31b-it:free",
+		"openrouter:moonshotai/kimi-k2",
 	},
 }
 

--- a/llm/provider.go
+++ b/llm/provider.go
@@ -88,6 +88,25 @@ var KnownModels = map[string][]string{
 		"o3-mini",
 		"o4-mini",
 	},
+	// Groq's free tier covers all listed models within rate limits
+	// (~14k req/day at writing). Names are passed through to Groq's
+	// OpenAI compatible endpoint with the "groq:" prefix stripped.
+	"groq": {
+		"groq:llama-3.3-70b-versatile",
+		"groq:llama-3.1-8b-instant",
+		"groq:mixtral-8x7b-32768",
+		"groq:gemma2-9b-it",
+		"groq:llama-3.2-90b-vision-preview",
+	},
+	// OpenRouter routes named with a ":free" suffix run on free tier
+	// quotas (~200 req/day at writing). Curated list of useful free
+	// routes. Users can also pass any other openrouter:<route> name.
+	"openrouter": {
+		"openrouter:meta-llama/llama-3.3-70b-instruct:free",
+		"openrouter:google/gemini-2.5-flash-exp:free",
+		"openrouter:qwen/qwen-2.5-72b-instruct:free",
+		"openrouter:nousresearch/hermes-3-llama-3.1-405b:free",
+	},
 }
 
 // isDatedVariant reports whether name looks like a friendly model with a
@@ -124,9 +143,20 @@ func IsKnownModel(name string) bool {
 
 // Resolve maps a model name to the correct provider using the given config.
 // For Anthropic and OpenAI, the model must be in KnownModels or Resolve errors.
-// Ollama accepts any name since users pull arbitrary local models.
+// Groq and OpenRouter accept any model name after the prefix since their
+// catalogs are large and change frequently. Ollama accepts any local name.
 func Resolve(name string, pc config.ProviderConfig) (Provider, error) {
 	switch {
+	case strings.HasPrefix(name, "groq:"):
+		if pc.GroqKey == "" {
+			return nil, fmt.Errorf("GROQ_API_KEY not configured")
+		}
+		return NewOpenAI(pc.GroqKey, "https://api.groq.com/openai/v1", strings.TrimPrefix(name, "groq:")), nil
+	case strings.HasPrefix(name, "openrouter:"):
+		if pc.OpenRouterKey == "" {
+			return nil, fmt.Errorf("OPENROUTER_API_KEY not configured")
+		}
+		return NewOpenAI(pc.OpenRouterKey, "https://openrouter.ai/api/v1", strings.TrimPrefix(name, "openrouter:")), nil
 	case strings.HasPrefix(name, "gpt-") || strings.HasPrefix(name, "o1-") || strings.HasPrefix(name, "o3-") || strings.HasPrefix(name, "o4-"):
 		if pc.OpenAIKey == "" {
 			return nil, fmt.Errorf("OPENAI_API_KEY not configured")
@@ -152,4 +182,17 @@ func Resolve(name string, pc config.ProviderConfig) (Provider, error) {
 		}
 		return nil, fmt.Errorf("unknown model: %s", name)
 	}
+}
+
+// IsFreeModel reports whether running the given model is free at time of
+// writing. Conservative: only marks names known to map to free quotas.
+// Used by display layers to tag dropdown entries.
+func IsFreeModel(name string) bool {
+	if strings.HasPrefix(name, "groq:") {
+		return true
+	}
+	if strings.HasPrefix(name, "openrouter:") && strings.HasSuffix(name, ":free") {
+		return true
+	}
+	return false
 }

--- a/llm/provider_test.go
+++ b/llm/provider_test.go
@@ -70,3 +70,61 @@ func TestResolveAllowsAnyOllamaModel(t *testing.T) {
 		t.Fatal("expected provider, got nil")
 	}
 }
+
+func TestResolveGroqRoutesAnyModelAfterPrefix(t *testing.T) {
+	p, err := Resolve("groq:llama-3.3-70b-versatile", config.ProviderConfig{GroqKey: "k"})
+	if err != nil {
+		t.Fatalf("expected groq route, got: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected provider, got nil")
+	}
+
+	// Any name after the prefix should resolve. The Groq catalog is large.
+	if _, err := Resolve("groq:something-new-tomorrow", config.ProviderConfig{GroqKey: "k"}); err != nil {
+		t.Errorf("groq prefix should accept any name, got: %v", err)
+	}
+}
+
+func TestResolveGroqRequiresKey(t *testing.T) {
+	_, err := Resolve("groq:llama-3.3-70b-versatile", config.ProviderConfig{})
+	if err == nil || !strings.Contains(err.Error(), "GROQ_API_KEY") {
+		t.Errorf("expected GROQ_API_KEY error, got: %v", err)
+	}
+}
+
+func TestResolveOpenRouterRoutesAnyModelAfterPrefix(t *testing.T) {
+	p, err := Resolve("openrouter:meta-llama/llama-3.3-70b-instruct:free", config.ProviderConfig{OpenRouterKey: "k"})
+	if err != nil {
+		t.Fatalf("expected openrouter route, got: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected provider, got nil")
+	}
+}
+
+func TestResolveOpenRouterRequiresKey(t *testing.T) {
+	_, err := Resolve("openrouter:meta-llama/llama-3.3-70b-instruct:free", config.ProviderConfig{})
+	if err == nil || !strings.Contains(err.Error(), "OPENROUTER_API_KEY") {
+		t.Errorf("expected OPENROUTER_API_KEY error, got: %v", err)
+	}
+}
+
+func TestIsFreeModel(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"groq:llama-3.3-70b-versatile", true},
+		{"openrouter:meta-llama/llama-3.3-70b-instruct:free", true},
+		{"openrouter:anthropic/claude-3.5-sonnet", false},
+		{"claude-haiku-4-5", false},
+		{"gpt-4o-mini", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := IsFreeModel(c.name); got != c.want {
+			t.Errorf("IsFreeModel(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds Groq and OpenRouter as LLM providers. Both have free tiers with daily quotas, useful for testing or low volume personal use without burning paid credits. Configured via existing setup flow and switchable at runtime via `/model`.

## Changes

- `llm/provider.go`: route `groq:` and `openrouter:` prefixes to their OpenAI-compatible endpoints. Catalogs added to `KnownModels`. New `IsFreeModel` helper.
- `llm/image.go`: added `gemini` marker so OpenRouter Gemini Flash gets the vision tag. Groq's `*-vision-preview` already matched.
- `config/config.go`: `GroqAPIKey` and `OpenRouterAPIKey` fields plus `ProviderConfig` wiring.
- `config/setup.go`: single LLM providers section prompts all five backends. Default model suggestion falls through Anthropic > OpenAI > Groq > OpenRouter > Ollama.
- `discord/commands.go`: `/model` dropdown and `/model` status include Groq and OpenRouter sections.
- `README.md`: provider table with signup URLs.
- `llm/provider_test.go`: prefix routing, missing-key errors, `IsFreeModel`.