### PR TITLE
fix(llm): remove duplicate /v1 from groq and openrouter base urls

### DIFF
--- a/llm/provider.go
+++ b/llm/provider.go
@@ -156,12 +156,12 @@ func Resolve(name string, pc config.ProviderConfig) (Provider, error) {
 		if pc.GroqKey == "" {
 			return nil, fmt.Errorf("GROQ_API_KEY not configured")
 		}
-		return NewOpenAI(pc.GroqKey, "https://api.groq.com/openai/v1", strings.TrimPrefix(name, "groq:")), nil
+		return NewOpenAI(pc.GroqKey, "https://api.groq.com/openai", strings.TrimPrefix(name, "groq:")), nil
 	case strings.HasPrefix(name, "openrouter:"):
 		if pc.OpenRouterKey == "" {
 			return nil, fmt.Errorf("OPENROUTER_API_KEY not configured")
 		}
-		return NewOpenAI(pc.OpenRouterKey, "https://openrouter.ai/api/v1", strings.TrimPrefix(name, "openrouter:")), nil
+		return NewOpenAI(pc.OpenRouterKey, "https://openrouter.ai/api", strings.TrimPrefix(name, "openrouter:")), nil
 	case strings.HasPrefix(name, "gpt-") || strings.HasPrefix(name, "o1-") || strings.HasPrefix(name, "o3-") || strings.HasPrefix(name, "o4-"):
 		if pc.OpenAIKey == "" {
 			return nil, fmt.Errorf("OPENAI_API_KEY not configured")


### PR DESCRIPTION
OpenRouter and Groq base URLs included a trailing `/v1`, but the shared
OpenAI-compatible client appends `/v1/chat/completions` to the base URL
on every request. This produced double `/v1` paths like:

- `https://openrouter.ai/api/v1/v1/chat/completions`
- `https://api.groq.com/openai/v1/v1/chat/completions`

The fix strips `/v1` from both base URLs so the final URL is constructed
correctly:
- `https://openrouter.ai/api/v1/chat/completions`
- `https://api.groq.com/openai/v1/chat/completions`