### PR TITLE
fix(setup): close provider gaps for Gemini, Groq, OpenRouter

### DIFF
--- a/config/models.go
+++ b/config/models.go
@@ -1,0 +1,64 @@
+package config
+
+// KnownModels is the canonical list of friendly model names per provider
+// that nevinho recognizes. Names outside this list resolve only when the
+// provider is Ollama (any local model name allowed) so a typo or stale
+// saved name fails loudly instead of producing 400s at request time.
+//
+// Dated variants like claude-haiku-4-5-20251001 are accepted by the upstream
+// API and used internally as defaults, but are not listed here to keep the
+// user facing menu compact.
+//
+// It lives in config, not llm, so the setup wizard and the llm resolver
+// share it without an import cycle. The setup wizard treats the first
+// entry of each list as that provider's default.
+var KnownModels = map[string][]string{
+	"anthropic": {
+		"claude-haiku-4-5",
+		"claude-sonnet-4-6",
+		"claude-sonnet-4-7",
+		"claude-opus-4-6",
+		"claude-opus-4-7",
+	},
+	"openai": {
+		"gpt-4o-mini",
+		"gpt-5-nano",
+		"gpt-5-mini",
+		"gpt-5",
+		"gpt-4o",
+		"gpt-4-turbo",
+		"o1-mini",
+		"o3-mini",
+		"o4-mini",
+	},
+	"gemini": {
+		"gemini-2.0-flash",
+		"gemini-2.0-flash-lite",
+		"gemini-1.5-pro",
+		"gemini-1.5-flash",
+	},
+	// Groq's free tier covers all listed models within rate limits
+	// (~14k req/day at writing). Names are passed through to Groq's
+	// OpenAI compatible endpoint with the "groq:" prefix stripped.
+	"groq": {
+		"groq:llama-3.3-70b-versatile",
+		"groq:llama-3.1-8b-instant",
+		"groq:mixtral-8x7b-32768",
+		"groq:gemma2-9b-it",
+		"groq:llama-3.2-90b-vision-preview",
+	},
+	// OpenRouter is a router across many providers. Routes ending in
+	// ":free" run on free tier quotas (~200 req/day at writing). Routes
+	// without ":free" are paid per token. Curated list mixes both. Users
+	// can also pass any other openrouter:<route> name.
+	"openrouter": {
+		"openrouter:nvidia/nemotron-3-super-120b-a12b:free",
+		"openrouter:openai/gpt-oss-120b:free",
+		"openrouter:openai/gpt-oss-20b:free",
+		"openrouter:inclusionai/ring-2.6-1t:free",
+		"openrouter:z-ai/glm-4.5-air:free",
+		"openrouter:minimax/minimax-m2.5:free",
+		"openrouter:google/gemma-4-31b-it:free",
+		"openrouter:moonshotai/kimi-k2",
+	},
+}

--- a/config/setup.go
+++ b/config/setup.go
@@ -74,17 +74,10 @@ func RunSetup(configDir string) error {
 		fmt.Println("  See README for signup URLs.")
 	}
 
-	// Default model. Suggest one based on the first configured provider so
-	// reinstall does not carry over a stale or invalid saved name.
-	if cfg.AnthropicAPIKey != "" || cfg.OpenAIAPIKey != "" || cfg.OllamaModel != "" ||
-		cfg.GeminiAPIKey != "" || cfg.GroqAPIKey != "" || cfg.OpenRouterAPIKey != "" {
-		fmt.Println()
-		fmt.Println("Default model")
-		suggested := cfg.Model
-		if suggested == "" {
-			suggested = suggestDefaultModel(cfg)
-		}
-		cfg.Model = prompt("Model name", suggested)
+	// Default model is derived, not prompted. The bot needs one to start on.
+	// Users switch any time in Discord with /model. A saved model is kept.
+	if cfg.Model == "" {
+		cfg.Model = defaultModel(cfg)
 	}
 
 	// Optional
@@ -122,7 +115,7 @@ func RunSetup(configDir string) error {
 	printStatus("  Tavily Search", cfg.TavilyAPIKey != "")
 	printStatus("  Voice", voice.IsAvailable(whisperDir))
 	if cfg.Model != "" {
-		fmt.Printf("  Model: %s\n", cfg.Model)
+		fmt.Printf("  Model: %s  (switch any time with /model in Discord)\n", cfg.Model)
 	}
 
 	fmt.Println()
@@ -131,22 +124,20 @@ func RunSetup(configDir string) error {
 	return nil
 }
 
-// suggestDefaultModel picks a sensible model name from the providers the
-// user just configured. Free providers come first when no paid key is
-// set so the bot starts on a no cost path. Order beyond that is
-// preference for general quality at a reasonable price.
-func suggestDefaultModel(cfg *Config) string {
+// defaultModel picks a starting model from the configured providers in
+// priority order. Ollama has no catalog, so its configured name is used directly.
+func defaultModel(cfg *Config) string {
 	switch {
 	case cfg.AnthropicAPIKey != "":
-		return "claude-haiku-4-5"
+		return KnownModels["anthropic"][0]
 	case cfg.OpenAIAPIKey != "":
-		return "gpt-4o-mini"
+		return KnownModels["openai"][0]
 	case cfg.GeminiAPIKey != "":
-		return "gemini-2.0-flash"
+		return KnownModels["gemini"][0]
 	case cfg.GroqAPIKey != "":
-		return "groq:llama-3.3-70b-versatile"
+		return KnownModels["groq"][0]
 	case cfg.OpenRouterAPIKey != "":
-		return "openrouter:meta-llama/llama-3.3-70b-instruct:free"
+		return KnownModels["openrouter"][0]
 	case cfg.OllamaModel != "":
 		return cfg.OllamaModel
 	}

--- a/discord/commands.go
+++ b/discord/commands.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/lucasnevespereira/nevinho/config"
 	"github.com/lucasnevespereira/nevinho/llm"
 	"github.com/lucasnevespereira/nevinho/schedule"
 )
@@ -332,27 +333,27 @@ func (b *Bot) modelOptions() []discordgo.SelectMenuOption {
 	var options []discordgo.SelectMenuOption
 
 	if pc.AnthropicKey != "" {
-		for _, name := range llm.KnownModels["anthropic"] {
+		for _, name := range config.KnownModels["anthropic"] {
 			options = append(options, modelOption(name, current))
 		}
 	}
 	if pc.OpenAIKey != "" {
-		for _, name := range llm.KnownModels["openai"] {
+		for _, name := range config.KnownModels["openai"] {
 			options = append(options, modelOption(name, current))
 		}
 	}
 	if pc.GeminiKey != "" {
-		for _, name := range llm.KnownModels["gemini"] {
+		for _, name := range config.KnownModels["gemini"] {
 			options = append(options, modelOption(name, current))
 		}
 	}
 	if pc.GroqKey != "" {
-		for _, name := range llm.KnownModels["groq"] {
+		for _, name := range config.KnownModels["groq"] {
 			options = append(options, modelOption(name, current))
 		}
 	}
 	if pc.OpenRouterKey != "" {
-		for _, name := range llm.KnownModels["openrouter"] {
+		for _, name := range config.KnownModels["openrouter"] {
 			options = append(options, modelOption(name, current))
 		}
 	}
@@ -392,35 +393,35 @@ func (b *Bot) modelStatus() string {
 
 	if pc.AnthropicKey != "" {
 		sb.WriteString("**Anthropic**\n")
-		for _, m := range llm.KnownModels["anthropic"] {
+		for _, m := range config.KnownModels["anthropic"] {
 			fmt.Fprintf(&sb, "• `%s`%s\n", m, visionTag(m))
 		}
 		sb.WriteString("\n")
 	}
 	if pc.OpenAIKey != "" {
 		sb.WriteString("**OpenAI**\n")
-		for _, m := range llm.KnownModels["openai"] {
+		for _, m := range config.KnownModels["openai"] {
 			fmt.Fprintf(&sb, "• `%s`%s\n", m, visionTag(m))
 		}
 		sb.WriteString("\n")
 	}
 	if pc.GeminiKey != "" {
 		sb.WriteString("**Gemini**\n")
-		for _, m := range llm.KnownModels["gemini"] {
+		for _, m := range config.KnownModels["gemini"] {
 			fmt.Fprintf(&sb, "• `%s`%s\n", m, visionTag(m))
 		}
 		sb.WriteString("\n")
 	}
 	if pc.GroqKey != "" {
 		sb.WriteString("**Groq**\n")
-		for _, m := range llm.KnownModels["groq"] {
+		for _, m := range config.KnownModels["groq"] {
 			fmt.Fprintf(&sb, "• `%s`%s\n", m, visionTag(m))
 		}
 		sb.WriteString("\n")
 	}
 	if pc.OpenRouterKey != "" {
 		sb.WriteString("**OpenRouter**\n")
-		for _, m := range llm.KnownModels["openrouter"] {
+		for _, m := range config.KnownModels["openrouter"] {
 			fmt.Fprintf(&sb, "• `%s`%s\n", m, visionTag(m))
 		}
 		sb.WriteString("\n")
@@ -535,7 +536,12 @@ func (b *Bot) reloadProvider() {
 }
 
 func isLLMKey(key string) bool {
-	return key == "ANTHROPIC_API_KEY" || key == "OPENAI_API_KEY" || key == "GEMINI_API_KEY" || key == "OLLAMA_MODEL"
+	switch key {
+	case "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY",
+		"GROQ_API_KEY", "OPENROUTER_API_KEY", "OLLAMA_MODEL":
+		return true
+	}
+	return false
 }
 
 // scheduleAction handles /schedules: list (default), pause, resume, delete.

--- a/llm/provider.go
+++ b/llm/provider.go
@@ -61,65 +61,6 @@ type ToolDef struct {
 	Schema      string
 }
 
-// KnownModels is the canonical list of friendly model names per provider
-// that nevinho recognizes. Names outside this list resolve only when the
-// provider is Ollama (any local model name allowed) so a typo or stale
-// saved name fails loudly instead of producing 400s at request time.
-//
-// Dated variants like claude-haiku-4-5-20251001 are accepted by the upstream
-// API and used internally as defaults, but are not listed here to keep the
-// user facing menu compact.
-var KnownModels = map[string][]string{
-	"anthropic": {
-		"claude-haiku-4-5",
-		"claude-sonnet-4-6",
-		"claude-sonnet-4-7",
-		"claude-opus-4-6",
-		"claude-opus-4-7",
-	},
-	"openai": {
-		"gpt-5-nano",
-		"gpt-5-mini",
-		"gpt-5",
-		"gpt-4o-mini",
-		"gpt-4o",
-		"gpt-4-turbo",
-		"o1-mini",
-		"o3-mini",
-		"o4-mini",
-	},
-	"gemini": {
-		"gemini-2.0-flash",
-		"gemini-2.0-flash-lite",
-		"gemini-1.5-pro",
-		"gemini-1.5-flash",
-	},
-	// Groq's free tier covers all listed models within rate limits
-	// (~14k req/day at writing). Names are passed through to Groq's
-	// OpenAI compatible endpoint with the "groq:" prefix stripped.
-	"groq": {
-		"groq:llama-3.3-70b-versatile",
-		"groq:llama-3.1-8b-instant",
-		"groq:mixtral-8x7b-32768",
-		"groq:gemma2-9b-it",
-		"groq:llama-3.2-90b-vision-preview",
-	},
-	// OpenRouter is a router across many providers. Routes ending in
-	// ":free" run on free tier quotas (~200 req/day at writing). Routes
-	// without ":free" are paid per token. Curated list mixes both. Users
-	// can also pass any other openrouter:<route> name.
-	"openrouter": {
-		"openrouter:nvidia/nemotron-3-super-120b-a12b:free",
-		"openrouter:openai/gpt-oss-120b:free",
-		"openrouter:openai/gpt-oss-20b:free",
-		"openrouter:inclusionai/ring-2.6-1t:free",
-		"openrouter:z-ai/glm-4.5-air:free",
-		"openrouter:minimax/minimax-m2.5:free",
-		"openrouter:google/gemma-4-31b-it:free",
-		"openrouter:moonshotai/kimi-k2",
-	},
-}
-
 // isDatedVariant reports whether name looks like a friendly model with a
 // trailing date suffix (e.g. claude-haiku-4-5-20251001). Such names route
 // to the same provider as their friendly counterpart.
@@ -139,7 +80,7 @@ func isDatedVariant(name string) bool {
 // IsKnownModel reports whether name appears in any provider's KnownModels
 // list, or is a dated variant of one of those names.
 func IsKnownModel(name string) bool {
-	for _, models := range KnownModels {
+	for _, models := range config.KnownModels {
 		for _, m := range models {
 			if m == name {
 				return true


### PR DESCRIPTION
## What

The setup wizard never asked for a Gemini API key even though the provider shipped, and `/config` did not hot-reload Groq or OpenRouter keys. This brings every code path that deals with providers in line so adding a provider does not leave stragglers behind. Also moves the model catalog into `config` as a single source of truth and drops the model prompt from setup in favor of a derived default.

## Changes

- Setup wizard now prompts for the Gemini API key and counts it in the no-provider warning, the default-model derivation, and the summary
- Move `KnownModels` from `llm` to `config` so the wizard and the resolver share one catalog without an import cycle
- Setup no longer prompts for a model. It derives a default from the configured providers and tells the user to switch with `/model` in Discord
- `isLLMKey` now includes `GROQ_API_KEY` and `OPENROUTER_API_KEY` so `/config` hot-reloads them like the other providers
- Drop the stale free-vs-paid comment on the model picker that did not match the code