### PR TITLE
fix(llm): refresh provider model catalogs

### DIFF
--- a/config/models.go
+++ b/config/models.go
@@ -16,7 +16,6 @@ var KnownModels = map[string][]string{
 	"anthropic": {
 		"claude-haiku-4-5",
 		"claude-sonnet-4-6",
-		"claude-sonnet-4-7",
 		"claude-opus-4-6",
 		"claude-opus-4-7",
 	},
@@ -42,9 +41,12 @@ var KnownModels = map[string][]string{
 	"groq": {
 		"groq:llama-3.3-70b-versatile",
 		"groq:llama-3.1-8b-instant",
-		"groq:mixtral-8x7b-32768",
-		"groq:gemma2-9b-it",
-		"groq:llama-3.2-90b-vision-preview",
+		"groq:meta-llama/llama-4-scout-17b-16e-instruct",
+		"groq:meta-llama/llama-4-maverick-17b-128e-instruct",
+		"groq:openai/gpt-oss-120b",
+		"groq:openai/gpt-oss-20b",
+		"groq:qwen/qwen3-32b",
+		"groq:moonshotai/kimi-k2-instruct-0905",
 	},
 	// OpenRouter is a router across many providers. Routes ending in
 	// ":free" run on free tier quotas (~200 req/day at writing). Routes
@@ -52,12 +54,14 @@ var KnownModels = map[string][]string{
 	// can also pass any other openrouter:<route> name.
 	"openrouter": {
 		"openrouter:nvidia/nemotron-3-super-120b-a12b:free",
-		"openrouter:openai/gpt-oss-120b:free",
-		"openrouter:openai/gpt-oss-20b:free",
-		"openrouter:inclusionai/ring-2.6-1t:free",
-		"openrouter:z-ai/glm-4.5-air:free",
-		"openrouter:minimax/minimax-m2.5:free",
 		"openrouter:google/gemma-4-31b-it:free",
-		"openrouter:moonshotai/kimi-k2",
+		"openrouter:inclusionai/ring-2.6-1t:free",
+		"openrouter:deepseek/deepseek-v4-flash:free",
+		"openrouter:anthropic/claude-opus-4.7",
+		"openrouter:deepseek/deepseek-v4-pro",
+		"openrouter:moonshotai/kimi-k2.6",
+		"openrouter:minimax/minimax-m2.7",
+		"openrouter:x-ai/grok-4.20",
+		"openrouter:z-ai/glm-5-turbo",
 	},
 }


### PR DESCRIPTION
## What

Several entries in `KnownModels` pointed at models the providers have retired, so selecting them in `/model` returned a 404 at request time. This refreshes Anthropic, Groq, and OpenRouter against what each provider currently serves. OpenAI was left alone, nothing there looked broken.

## Changes

- Anthropic: drop `claude-sonnet-4-7`, which never existed (latest Sonnet is 4.6)
- Groq: drop the deprecated `mixtral-8x7b-32768`, `gemma2-9b-it`, and `llama-3.2-90b-vision-preview`; add Llama 4 Scout and Maverick, gpt-oss-120b/20b, qwen3-32b, and kimi-k2
- OpenRouter: five of eight slugs no longer resolve; keep the three that still work and add deepseek-v4-flash:free plus the popular paid models (claude-opus-4.7, deepseek-v4-pro, kimi-k2.6, minimax-m2.7, grok-4.20, glm-5-turbo)

## Note

The Groq and OpenRouter catalogs drift fast and this is the second stale-catalog fix in a row. The durable fix is to pull each provider's `/models` endpoint at startup instead of hardcoding slugs. Worth a separate issue.