### PR TITLE
feat(agent): guarantee a reply and normalize provider stop reasons

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -212,6 +212,7 @@ func (a *Agent) Chat(userID, text string, isVoice bool, images []llm.Image) (str
 		a.summarizeAndPrepend(userID, evicted)
 	}
 
+	var lastText string
 	for range maxLoops {
 		if ctx.Err() != nil {
 			return "Cancelled.", nil
@@ -231,12 +232,34 @@ func (a *Agent) Chat(userID, text string, isVoice bool, images []llm.Image) (str
 		usage.Out += resp.Usage.Out
 		cacheRead += resp.Usage.CacheRead
 		a.appendHistory(userID, resp.AssistantMessage)
+		if resp.Text != "" {
+			lastText = resp.Text
+		}
 
 		if len(resp.ToolCalls) == 0 {
-			a.addTokens(usage.In, usage.Out)
-			logger.Done(start, usage.In, usage.Out, cacheRead, toolsUsed, estimateCost(a.llm.Model(), usage.In, usage.Out))
-			logger.Nevinho(resp.Text)
-			return resp.Text, nil
+			reply := resp.Text
+			// Empty terminal turn: the model stopped with no tool call
+			// and no text. Gemini does this after a tool loop. One more
+			// pass with tools off forces it to answer in words.
+			if reply == "" {
+				nudged, nudgeUsage := a.nudgeForReply(ctx, userID, prompt)
+				usage.In += nudgeUsage.In
+				usage.Out += nudgeUsage.Out
+				cacheRead += nudgeUsage.CacheRead
+				reply = nudged
+			}
+			if reply == "" {
+				reply = lastText
+			}
+			if reply == "" {
+				reply = "I finished, but could not put a reply together. Ask me to recap."
+			}
+			// Output hit the token cap mid-sentence. Flag it instead of
+			// sending a silently truncated message.
+			if resp.StopReason == llm.StopMaxTokens && reply == resp.Text {
+				reply += "\n\n_(cut off at the length limit. Ask me to continue.)_"
+			}
+			return a.finish(start, usage, cacheRead, toolsUsed, reply)
 		}
 
 		var results []llm.ToolResult
@@ -266,19 +289,41 @@ func (a *Agent) Chat(userID, text string, isVoice bool, images []llm.Image) (str
 
 		if needsApproval {
 			p := a.tools.PendingApproval(userID)
-			reply := approvalMessage(p)
-			a.addTokens(usage.In, usage.Out)
-			logger.Done(start, usage.In, usage.Out, cacheRead, toolsUsed, estimateCost(a.llm.Model(), usage.In, usage.Out))
-			logger.Nevinho(reply)
-			return reply, nil
+			return a.finish(start, usage, cacheRead, toolsUsed, approvalMessage(p))
 		}
 	}
 
-	reply := "I hit my limit on tool calls. Try breaking it into smaller tasks."
+	return a.finish(start, usage, cacheRead, toolsUsed, "I hit my limit on tool calls. Try breaking it into smaller tasks.")
+}
+
+// finish records token usage, logs the completed turn, and returns the
+// reply. Every terminal path in Chat goes through it so accounting and
+// logging stay identical no matter which exit the loop takes.
+func (a *Agent) finish(start time.Time, usage llm.Usage, cacheRead int, toolsUsed []string, reply string) (string, error) {
 	a.addTokens(usage.In, usage.Out)
 	logger.Done(start, usage.In, usage.Out, cacheRead, toolsUsed, estimateCost(a.llm.Model(), usage.In, usage.Out))
 	logger.Nevinho(reply)
 	return reply, nil
+}
+
+// nudgeForReply runs one extra completion with tools disabled, used when
+// the model ends a turn with neither text nor a tool call. With no tools
+// to reach for, it has to answer in plain text. Returns "" if even this
+// comes back empty, leaving the caller to fall back.
+func (a *Agent) nudgeForReply(ctx context.Context, userID, prompt string) (string, llm.Usage) {
+	a.appendHistory(userID, a.llm.FormatUserMessage(
+		"[Your last turn was empty. Reply to the user now in plain text. Summarize what you did and answer them.]", nil))
+	resp, err := a.llm.Complete(ctx, &llm.Request{
+		SystemPrompt: prompt,
+		Messages:     a.history[userID],
+		MaxTokens:    maxOutputTokens,
+	})
+	if err != nil {
+		logger.Err(fmt.Errorf("reply nudge failed: %w", err))
+		return "", llm.Usage{}
+	}
+	a.appendHistory(userID, resp.AssistantMessage)
+	return resp.Text, resp.Usage
 }
 
 // MemoryView returns the user-visible dump of memory.md entries.

--- a/llm/anthropic.go
+++ b/llm/anthropic.go
@@ -77,6 +77,7 @@ func (a *Anthropic) Complete(ctx context.Context, req *Request) (*Response, erro
 			CacheRead:  raw.Usage.CacheReadInputTokens,
 			CacheWrite: raw.Usage.CacheCreationInputTokens,
 		},
+		StopReason: anthropicStopReason(raw.StopReason),
 	}
 
 	assistantMsg, _ := json.Marshal(map[string]interface{}{
@@ -106,6 +107,20 @@ func (a *Anthropic) Complete(ctx context.Context, req *Request) (*Response, erro
 	resp.Text = strings.Join(textParts, "\n")
 
 	return resp, nil
+}
+
+// anthropicStopReason maps Anthropic's stop_reason onto the normalized set.
+func anthropicStopReason(s string) StopReason {
+	switch s {
+	case "tool_use":
+		return StopToolUse
+	case "max_tokens":
+		return StopMaxTokens
+	case "end_turn", "stop_sequence":
+		return StopEndTurn
+	default:
+		return StopOther
+	}
 }
 
 func (a *Anthropic) FormatUserMessage(text string, images []Image) json.RawMessage {

--- a/llm/gemini.go
+++ b/llm/gemini.go
@@ -113,7 +113,25 @@ func (g *Gemini) Complete(ctx context.Context, req *Request) (*Response, error) 
 		}
 	}
 
+	resp.StopReason = geminiStopReason(cand.FinishReason, len(resp.ToolCalls) > 0)
 	return resp, nil
+}
+
+// geminiStopReason maps Gemini's finishReason onto the normalized set.
+// Gemini keeps finishReason as "STOP" even when the turn carries function
+// calls, so tool use is detected from the parsed parts, not the reason.
+func geminiStopReason(s string, hasToolCalls bool) StopReason {
+	if hasToolCalls {
+		return StopToolUse
+	}
+	switch s {
+	case "STOP":
+		return StopEndTurn
+	case "MAX_TOKENS":
+		return StopMaxTokens
+	default:
+		return StopOther
+	}
 }
 
 func (g *Gemini) FormatUserMessage(text string, images []Image) json.RawMessage {

--- a/llm/openai.go
+++ b/llm/openai.go
@@ -32,10 +32,10 @@ func (o *OpenAI) Complete(ctx context.Context, req *Request) (*Response, error) 
 	messages := append([]json.RawMessage{sysMsg}, ensureSlice(req.Messages)...)
 
 	body := map[string]interface{}{
-		"model":      o.model,
+		"model":                 o.model,
 		"max_completion_tokens": req.MaxTokens,
-		"messages":   messages,
-		"tools":      o.formatTools(req.Tools),
+		"messages":              messages,
+		"tools":                 o.formatTools(req.Tools),
 	}
 
 	data, err := doHTTP(ctx, o.baseURL+"/v1/chat/completions", body, map[string]string{
@@ -49,8 +49,8 @@ func (o *OpenAI) Complete(ctx context.Context, req *Request) (*Response, error) 
 	var raw struct {
 		Choices []struct {
 			Message struct {
-				Role      string          `json:"role"`
-				Content   *string         `json:"content"`
+				Role      string           `json:"role"`
+				Content   *string          `json:"content"`
 				ToolCalls []openAIToolCall `json:"tool_calls"`
 			} `json:"message"`
 			FinishReason string `json:"finish_reason"`
@@ -70,7 +70,8 @@ func (o *OpenAI) Complete(ctx context.Context, req *Request) (*Response, error) 
 
 	choice := raw.Choices[0]
 	resp := &Response{
-		Usage: Usage{In: raw.Usage.PromptTokens, Out: raw.Usage.CompletionTokens},
+		Usage:      Usage{In: raw.Usage.PromptTokens, Out: raw.Usage.CompletionTokens},
+		StopReason: openAIStopReason(choice.FinishReason),
 	}
 
 	assistantMsg, _ := json.Marshal(choice.Message)
@@ -89,6 +90,21 @@ func (o *OpenAI) Complete(ctx context.Context, req *Request) (*Response, error) 
 	}
 
 	return resp, nil
+}
+
+// openAIStopReason maps the OpenAI-style finish_reason onto the normalized
+// set. Groq, OpenRouter, and Ollama all speak this same dialect.
+func openAIStopReason(s string) StopReason {
+	switch s {
+	case "tool_calls", "function_call":
+		return StopToolUse
+	case "length":
+		return StopMaxTokens
+	case "stop":
+		return StopEndTurn
+	default:
+		return StopOther
+	}
 }
 
 func (o *OpenAI) FormatUserMessage(text string, images []Image) json.RawMessage {

--- a/llm/provider.go
+++ b/llm/provider.go
@@ -34,7 +34,20 @@ type Response struct {
 	ToolCalls        []ToolCall
 	Usage            Usage
 	AssistantMessage json.RawMessage
+	StopReason       StopReason
 }
+
+// StopReason is the normalized reason a provider stopped generating. Each
+// provider maps its own native reason onto these so the agent loop can read
+// the model's intent instead of guessing it from the shape of the output.
+type StopReason string
+
+const (
+	StopEndTurn   StopReason = "end_turn"   // finished a complete reply
+	StopToolUse   StopReason = "tool_use"   // wants tool results before continuing
+	StopMaxTokens StopReason = "max_tokens" // hit the output token cap, truncated
+	StopOther     StopReason = "other"      // safety filter, unknown, or unset
+)
 
 type ToolCall struct {
 	ID    string

--- a/llm/stopreason_test.go
+++ b/llm/stopreason_test.go
@@ -1,0 +1,54 @@
+package llm
+
+import "testing"
+
+func TestAnthropicStopReason(t *testing.T) {
+	cases := map[string]StopReason{
+		"tool_use":      StopToolUse,
+		"max_tokens":    StopMaxTokens,
+		"end_turn":      StopEndTurn,
+		"stop_sequence": StopEndTurn,
+		"refusal":       StopOther,
+		"":              StopOther,
+	}
+	for in, want := range cases {
+		if got := anthropicStopReason(in); got != want {
+			t.Errorf("anthropicStopReason(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestOpenAIStopReason(t *testing.T) {
+	cases := map[string]StopReason{
+		"tool_calls":     StopToolUse,
+		"function_call":  StopToolUse,
+		"length":         StopMaxTokens,
+		"stop":           StopEndTurn,
+		"content_filter": StopOther,
+		"":               StopOther,
+	}
+	for in, want := range cases {
+		if got := openAIStopReason(in); got != want {
+			t.Errorf("openAIStopReason(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestGeminiStopReason(t *testing.T) {
+	// Gemini reports STOP even when the turn carries function calls, so a
+	// tool call must win over the raw reason.
+	if got := geminiStopReason("STOP", true); got != StopToolUse {
+		t.Errorf("geminiStopReason(STOP, hasToolCalls) = %q, want %q", got, StopToolUse)
+	}
+	cases := map[string]StopReason{
+		"STOP":       StopEndTurn,
+		"MAX_TOKENS": StopMaxTokens,
+		"SAFETY":     StopOther,
+		"":           StopOther,
+	}
+	for in, want := range cases {
+		if got := geminiStopReason(in, false); got != want {
+			t.Errorf("geminiStopReason(%q, false) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## What

The agent loop could return an empty string when a model ended a turn with no text and no tool call (Gemini does this after a tool loop). Discord papered over it with "Done. (no text response)", but scheduled tasks and the CLI just got nothing back. This makes a non-empty reply a guarantee of `Chat()` itself, so every caller is reliable. It also threads each provider's stop reason through to the loop so termination is based on the model's actual intent instead of guessing from the shape of the output.

## Changes

- Add a normalized `llm.StopReason` (`end_turn`, `tool_use`, `max_tokens`, `other`) on `Response`; each provider maps its native reason onto it (Anthropic `stop_reason`, OpenAI-family `finish_reason`, Gemini `finishReason` with a tool-call override since Gemini reports `STOP` even when calling tools)
- `Chat()` now treats an empty terminal turn as its own case: one extra completion with tools disabled forces a text answer, then falls back to the last non-empty text, then a graceful message. It can no longer return `""`
- Flag `max_tokens` truncation in the reply instead of sending a silently cut-off message
- Extract `finish()` so every terminal path in the loop shares one token-accounting and logging block
- Tests for the three stop-reason mappings

## Follow-ups (not in this PR)

- Retry transient HTTP failures in `doHTTP`
- Smarter tool-result truncation (currently a blunt 4000-char cut)
- Lock `appendHistory` to close the scheduler-vs-live-user history race