### PR TITLE
perf(agent): run read-only tool calls concurrently

### DIFF
--- a/agent/loop.go
+++ b/agent/loop.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/lucasnevespereira/nevinho/llm"
@@ -140,21 +141,43 @@ func (a *Agent) Chat(userID, text string, isVoice bool, images []llm.Image) (str
 			return a.finish(start, usage, cacheRead, toolsUsed, reply)
 		}
 
-		var results []llm.ToolResult
-		needsApproval := false
+		// Announce the whole batch before running any, so the activity
+		// indicator shows every tool starting together.
 		for _, tc := range resp.ToolCalls {
 			toolsUsed = append(toolsUsed, tc.Name)
 			detail := toolDetail(tc.Name, tc.Input)
 			logger.Tool(tc.Name, detail)
 			a.emitToolEvent(userID, tc.Name, detail)
-			output := a.executeTool(ctx, tc.Name, tc.Input, userID)
-			if len(output) > maxToolResult {
-				output = output[:maxToolResult] + "\n...(truncated)"
+		}
+
+		// Run the calls, keeping their emitted order. A run of consecutive
+		// read-only tools goes concurrently; an effectful tool runs alone
+		// so anything before it finishes first and anything after sees its
+		// result. Same outcome as running everything serially, just faster
+		// when the model batches reads.
+		outputs := make([]string, len(resp.ToolCalls))
+		for i := 0; i < len(resp.ToolCalls); {
+			if !isReadOnlyTool(resp.ToolCalls[i].Name) {
+				outputs[i] = a.runTool(ctx, resp.ToolCalls[i], userID)
+				i++
+				continue
 			}
+			var wg sync.WaitGroup
+			for i < len(resp.ToolCalls) && isReadOnlyTool(resp.ToolCalls[i].Name) {
+				idx, tc := i, resp.ToolCalls[i]
+				wg.Go(func() { outputs[idx] = a.runTool(ctx, tc, userID) })
+				i++
+			}
+			wg.Wait()
+		}
+
+		var results []llm.ToolResult
+		needsApproval := false
+		for i, tc := range resp.ToolCalls {
+			output := outputs[i]
 			errored := isToolError(output)
 			logger.ToolResult(tc.Name, output, errored)
-			result := llm.ToolResult{ID: tc.ID, Output: output, IsError: errored}
-			results = append(results, result)
+			results = append(results, llm.ToolResult{ID: tc.ID, Output: output, IsError: errored})
 			if strings.HasPrefix(output, "NEEDS_APPROVAL:") {
 				needsApproval = true
 				a.mu.Lock()
@@ -231,6 +254,30 @@ func (a *Agent) executeTool(ctx context.Context, name string, input json.RawMess
 		}
 	}()
 	return a.tools.Execute(ctx, name, input, userID)
+}
+
+// runTool executes one tool call and caps its output. Safe to call from a
+// goroutine: executeTool recovers its own panics and the tools registry
+// guards its own state.
+func (a *Agent) runTool(ctx context.Context, tc llm.ToolCall, userID string) string {
+	out := a.executeTool(ctx, tc.Name, tc.Input, userID)
+	if len(out) > maxToolResult {
+		out = out[:maxToolResult] + "\n...(truncated)"
+	}
+	return out
+}
+
+// isReadOnlyTool reports whether a tool only reads state. Read-only calls
+// have no side effects, so a run of them can execute concurrently without
+// changing the result. Effectful tools (bash, file writes, schedule) stay
+// serial to keep their ordering.
+func isReadOnlyTool(name string) bool {
+	switch name {
+	case "web_search", "web_read", "file_read", "file_list", "grep", "find":
+		return true
+	default:
+		return false
+	}
 }
 
 func isToolError(output string) bool {


### PR DESCRIPTION
## What

When a model emits several tool calls in one turn, the loop ran them one after another. Coding work is read-heavy — reading several files, grep plus read — so a multi-tool turn waited on the sum of every call. This runs a consecutive run of read-only calls concurrently. Effectful tools stay serial, so the outcome is identical to running everything in order, just faster when the model batches reads.

## Changes

- Split the tool-handling block into phases: announce the batch, run the calls, then collect results serially
- A run of consecutive read-only tools (`web_search`, `web_read`, `file_read`, `file_list`, `grep`, `find`) executes concurrently. An effectful tool (`bash`, `file_write`, `file_edit`, `schedule`) runs alone in its emitted position, so anything before it finishes first and anything after sees its result
- Only `runTool` runs in goroutines. The tools registry already guards its own state with a mutex, so the sole shared write is each goroutine into its own slot of an `outputs` slice. Logging, activity events, approval bookkeeping, and history append all stay serial
- Result order is preserved by writing into fixed indices

## Why read-only only

Parallelizing every tool would, in theory, reorder dependent mutations if a model batched them (e.g. `file_write(X)` then `file_read(X)` in one turn). Restricting concurrency to read-only runs removes that entirely: reads have no side effects, so a group of them produces the same result in any order. Zero behavior change versus the serial loop.

Verified with `go test -race ./...` — no data races. All 253 tests pass.

Note: branch is named `feat/http-retry` from an earlier plan that got re-scoped.