### PR TITLE
feat(tui): theme

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/lucasnevespereira/nevinho/agent"
 	"github.com/lucasnevespereira/nevinho/config"
@@ -25,6 +28,15 @@ func Chat(configDir, version, selfDoc string) {
 		fmt.Fprintf(os.Stderr, "failed to load config: %v\n", err)
 		os.Exit(1)
 	}
+	// Keep boot-time logger.Info lines out of the TUI. Route them to
+	// chat.log if possible, otherwise drop them. The model is already in
+	// the status bar so the user does not need the boot line on screen.
+	if f, err := os.OpenFile(filepath.Join(configDir, "chat.log"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644); err == nil {
+		log.SetOutput(f)
+	} else {
+		log.SetOutput(io.Discard)
+	}
+
 	provider := detectProvider(cfg)
 	// Local mode: the agent knows it is in a terminal on the user's own
 	// machine, which sets its prompt and gates every bash command behind

--- a/tui/blocks.go
+++ b/tui/blocks.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/glamour"
+	"github.com/charmbracelet/glamour/ansi"
+	"github.com/charmbracelet/glamour/styles"
 )
 
 // cardPreviewLines caps how many lines of tool output a card shows.
@@ -235,6 +237,21 @@ func colorizeDiff(lines []string) {
 	}
 }
 
+// prosePalette returns a glamour style derived from the dark default,
+// with the inline code pill restyled to fit nevinho's palette.
+func prosePalette() ansi.StyleConfig {
+	cfg := styles.DarkStyleConfig
+	codeBg := "#1f2522"
+	codeFg := "#7fa6c9"
+	cfg.Code = ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Color:           &codeFg,
+			BackgroundColor: &codeBg,
+		},
+	}
+	return cfg
+}
+
 // mdRenderer is cached across blocks and rebuilt only when the width changes.
 var (
 	mdRenderer *glamour.TermRenderer
@@ -248,11 +265,13 @@ func renderMarkdown(s string, w int) string {
 		return s
 	}
 	if mdRenderer == nil || mdWidth != w {
-		// A fixed dark style, not WithAutoStyle: auto-style queries the
-		// terminal for its background colour, and that reply leaks into
-		// Bubble Tea's input as garbage keystrokes.
+		// A fixed style patched from the dark default. Auto-style queries
+		// the terminal for its background colour, and that reply leaks
+		// into Bubble Tea's input as garbage keystrokes. The patch swaps
+		// the loud red inline-code pill for a calm accent on a muted
+		// surface, so `code` spans blend with the rest of the palette.
 		r, err := glamour.NewTermRenderer(
-			glamour.WithStandardStyle("dark"),
+			glamour.WithStyles(prosePalette()),
 			glamour.WithWordWrap(w-4),
 		)
 		if err != nil {

--- a/tui/theme.go
+++ b/tui/theme.go
@@ -1,0 +1,62 @@
+package tui
+
+import "github.com/charmbracelet/lipgloss"
+
+// Design tokens for nevinho's terminal UI. Every visible style is built
+// from this palette so retuning the look is a single-file change.
+//
+// Tones are low-saturation hex colours, picked to blend like pi: surfaces
+// sit close in value, accents are soft rather than loud, and semantic
+// hues (success/danger/warn) keep their meaning without shouting.
+var (
+	// Surfaces. Backgrounds for the different block types. Close in
+	// value so cards and user turns feel like one cohesive transcript.
+	bgUser    = lipgloss.Color("#2c2c3a") // user turn bar, dusky lavender-grey
+	bgCard    = lipgloss.Color("#181c1a") // tool card body, very dark with a faint green tint
+	bgCardErr = lipgloss.Color("#3a1f1f") // tool card body on error, deep muted red
+	bgStatus  = lipgloss.Color("#1f1f24") // bottom status bar
+
+	// Foregrounds. Warm off-white primaries, dim warm grey for secondary.
+	fgPrimary = lipgloss.Color("#dcdcd6") // primary text on surfaces
+	fgBody    = lipgloss.Color("#c6c6c0") // body text on cards
+	fgMuted   = lipgloss.Color("#7a7a76") // hints, placeholders, secondary
+
+	// Accent. Soft blue, used for tool headers, selection, spinner.
+	accent = lipgloss.Color("#7fa6c9")
+
+	// Semantic. Muted versions of the conventional git/status hues so
+	// they read as meaning, not decoration.
+	success = lipgloss.Color("#8fb878") // diff add, written content
+	danger  = lipgloss.Color("#c97a7a") // errors, diff delete
+	warn    = lipgloss.Color("#d4a373") // approval, paused state
+	info    = lipgloss.Color("#7fa6c9") // diff hunk headers
+)
+
+// Styles composed from the palette. Block renders pin a width on top of
+// these so the tint runs edge to edge.
+var (
+	styleHint   = lipgloss.NewStyle().Foreground(fgMuted)
+	styleErr    = lipgloss.NewStyle().Foreground(danger)
+	styleStatus = lipgloss.NewStyle().Foreground(fgBody).Background(bgStatus)
+	styleSpin   = lipgloss.NewStyle().Foreground(accent)
+
+	// Flat input bar with hairline rules above and below. One row tall,
+	// edge to edge, pi-style.
+	styleInput     = lipgloss.NewStyle().Border(lipgloss.NormalBorder(), true, false, true, false).BorderForeground(fgMuted)
+	styleApprove   = lipgloss.NewStyle().Border(lipgloss.NormalBorder(), true, false, true, false).BorderForeground(warn)
+	styleApproveLn = lipgloss.NewStyle().Foreground(warn)
+
+	styleSelected = lipgloss.NewStyle().Foreground(accent).Bold(true)
+	styleToolHead = lipgloss.NewStyle().Foreground(accent).Bold(true)
+
+	styleUser    = lipgloss.NewStyle().Background(bgUser).Foreground(fgPrimary).Padding(1, 2)
+	styleCard    = lipgloss.NewStyle().Background(bgCard).Foreground(fgBody).Padding(1, 2)
+	styleCardErr = lipgloss.NewStyle().Background(bgCardErr).Foreground(fgPrimary).Padding(1, 2)
+
+	// Diff lines. Foreground only so the tint sits on top of the card,
+	// matching git's calm look rather than a loud full-line background.
+	styleDiffAdd  = lipgloss.NewStyle().Foreground(success)
+	styleDiffDel  = lipgloss.NewStyle().Foreground(danger)
+	styleDiffHunk = lipgloss.NewStyle().Foreground(info)
+	styleDiffMeta = lipgloss.NewStyle().Foreground(fgMuted)
+)

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -29,35 +29,6 @@ const userID = "terminal"
 // inputPlaceholder is the textarea's resting placeholder text.
 const inputPlaceholder = "Ask nevinho anything…"
 
-var (
-	colAccent = lipgloss.Color("12")
-	colDim    = lipgloss.Color("244")
-	colErr    = lipgloss.Color("9")
-	colWarn   = lipgloss.Color("214")
-
-	styleHint = lipgloss.NewStyle().Foreground(colDim)
-	styleErr  = lipgloss.NewStyle().Foreground(colErr)
-	// Flat input bar with hairline rules above and below. Matches the pi
-	// aesthetic of a single-row input instead of a chunky rounded box.
-	styleInput   = lipgloss.NewStyle().Border(lipgloss.NormalBorder(), true, false, true, false).BorderForeground(colDim)
-	styleApprove = lipgloss.NewStyle().Border(lipgloss.NormalBorder(), true, false, true, false).BorderForeground(colWarn)
-	styleApproveLn = lipgloss.NewStyle().Foreground(colWarn)
-	styleStatus    = lipgloss.NewStyle().Foreground(lipgloss.Color("250")).Background(lipgloss.Color("236"))
-	styleSpin      = lipgloss.NewStyle().Foreground(colAccent)
-	styleSelected  = lipgloss.NewStyle().Foreground(colAccent).Bold(true)
-	styleUser      = lipgloss.NewStyle().Background(lipgloss.Color("237")).Foreground(lipgloss.Color("252")).Padding(1, 2)
-	styleToolHead  = lipgloss.NewStyle().Foreground(lipgloss.Color("39")).Bold(true)
-	styleCard      = lipgloss.NewStyle().Background(lipgloss.Color("234")).Foreground(lipgloss.Color("250")).Padding(1, 2)
-	styleCardErr   = lipgloss.NewStyle().Background(lipgloss.Color("52")).Foreground(lipgloss.Color("252")).Padding(1, 2)
-
-	// Fg-only diff colours, like git diff: a calm green/red on the +/- lines
-	// rather than a loud full-line background.
-	styleDiffAdd  = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))
-	styleDiffDel  = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
-	styleDiffHunk = lipgloss.NewStyle().Foreground(lipgloss.Color("39"))
-	styleDiffMeta = lipgloss.NewStyle().Foreground(colDim)
-)
-
 // Run starts the terminal UI and blocks until the user quits. cwd shows in
 // the status bar. configDir is where the agent's log file is written.
 func Run(a *agent.Agent, cwd, configDir string) error {
@@ -164,17 +135,9 @@ func (m model) send(text string) tea.Cmd {
 	}
 }
 
-// maxContentWidth caps how wide rendered blocks get on wide terminals, so
-// long lines stay readable instead of stretching edge to edge. Matches the
-// ~100-col content width used by Claude Code and pi.
-const maxContentWidth = 100
-
-// contentWidth is the width passed to block renders: terminal width clamped
-// to maxContentWidth.
+// contentWidth is the width passed to block renders. Blocks stretch the
+// full terminal width, matching pi's edge-to-edge layout.
 func (m model) contentWidth() int {
-	if m.width > maxContentWidth {
-		return maxContentWidth
-	}
 	return m.width
 }
 
@@ -202,16 +165,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.input.SetWidth(m.width)
 		if !m.ready {
 			m.ready = true
-			// Print the greeting plus enough blank rows to push the live
-			// region toward the bottom of the terminal. Without this the
-			// input sits right under the greeting and the rest of the
-			// screen reads as dead space. As content grows, tea.Println
-			// pushes new blocks above the live region and the padding
-			// scrolls off naturally.
-			greeting := m.greeting().render(m.contentWidth())
-			liveHeight := 7 // blank row + workingLine + input (3 with border) + statusBar + safety
-			pad := max(m.height-lipgloss.Height(greeting)-liveHeight, 0)
-			return m, tea.Println("\n" + greeting + strings.Repeat("\n", pad))
+			// Print the greeting straight into scrollback. The live region
+			// sits right under it, and as content arrives new blocks push
+			// the greeting up naturally.
+			return m, tea.Println(m.greeting().render(m.contentWidth()))
 		}
 		return m, nil
 
@@ -403,7 +360,13 @@ func (m model) submit() (tea.Model, tea.Cmd) {
 	}
 	m.input.Reset()
 	if cmd, handled := m.handleSlash(text); handled {
-		return m, cmd
+		// Echo the command into scrollback so the transcript shows what
+		// the user typed, same as a normal turn.
+		echo := m.printBlock(userBlock{text})
+		if cmd == nil {
+			return m, echo
+		}
+		return m, tea.Sequence(echo, cmd)
 	}
 	m.busy = true
 	return m, tea.Batch(


### PR DESCRIPTION
## What
Adds a design system for the TUI with intentional color tokens living in a single theme file. The markdown renderer now uses a custom palette that replaces the loud red inline-code pill with a soft accent on muted surface, keeping prose in harmony with the rest of the palette. Boot logs route to chat.log or get discarded so the TUI starts clean. The layout drops pre-padding and the 100-column content cap, letting the greeting sit naturally in scrollback.

## Changes
- Extract color palette to `tui/theme.go` with design tokens (surfaces, foregrounds, accents, semantic colors)
- Add `prosePalette()` to customize glamour's markdown style with soft-accent inline code
- Update markdown renderer to use the custom palette instead of dark default
- Suppress boot-time logger output in TUI: route to chat.log or discard
- Remove 100-column content width cap, stretch full terminal width
- Simplify greeting layout by removing pre-padding calculation
- Echo slash commands into scrollback so they appear in the transcript