### PR TITLE
Terminal DX: file mentions, history recall, multi-line, real cost tracking

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,6 +81,17 @@ The terminal client uses one shared summary today, so context from project A lea
 - [ ] `/forget` clears just the current cwd's summary, not all of them.
 - [ ] `/session` in the terminal mentions which cwd is currently active.
 
+### Terminal UI follow-ups
+
+The TUI is the primary surface when nevinho is used as a coding agent. After the recent DX pass, these are the remaining rough edges.
+
+- [ ] Mask API key values while typing through `/config`. The textarea echoes whatever is typed; a paste shows the key on screen until enter clears the input.
+- [ ] Slash-command autocomplete picker. The inline hint shows matching names; a real picker on `/` would let the user pick instead of finishing the word.
+- [ ] Tool card expand. Print the full output of the previous tool call without tailing `chat.log`. Either a `/last` command or a keystroke on the last card.
+- [ ] `/diff` to show pending `file_edit` and `file_write` changes the agent staged but the user has not approved.
+- [ ] `/cd <path>` to change the agent's working directory without restarting nevinho.
+- [ ] Session list and `/load <id>` to resume a past saved summary instead of starting cold.
+
 ### Scheduled tasks: follow-ups
 
 Foundation shipped. Remaining work:
@@ -131,3 +142,4 @@ Real but deferred. Ship when the above is solid or when a user hits the pain.
 - [x] **Strict approval mode for the terminal.** Every bash command and every write outside the current directory asks via an inline yes/no picker. Deny path tells the model to stop instead of retrying.
 - [x] **Path management UI.** `/paths` lists approved paths and revokes one at a time. `/paths clear` wipes all. Backed by `tools.Registry.RevokePath`.
 - [x] **Filesystem-aware upgrade and uninstall.** Detect daemon vs terminal use via the presence of the systemd unit file. A terminal-only Linux user never gets a service they did not ask for.
+- [x] **Terminal DX pass.** `@file` picker inserts a project path into the prompt (git-aware, falls back to walk). Up/down arrows recall prior prompts (100-entry ring). Multi-line input via ctrl+j (or shift+enter on terminals with the kitty protocol), auto-grows up to 6 rows. Slash-command typos no longer leave a user bubble in scrollback. `/help` lists subcommand syntax. Cost table covers Gemini, Groq, and free OpenRouter variants so the status bar reads honestly. Status bar cost rounded to two decimals.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -345,27 +345,65 @@ func (a *Agent) Status() string {
 	return sb.String()
 }
 
+// estimateCost returns an approximate USD cost for a turn given a model
+// name and token counts. Prices are per 1M tokens, taken from each
+// provider's public pricing page. Local and unknown models return 0.
+//
+// Free OpenRouter variants (suffix ":free") return 0 even if the base
+// model is paid, so the status bar reads honestly while testing.
 func estimateCost(model string, tokensIn, tokensOut int) float64 {
-	var inPer1M, outPer1M float64
-	switch {
-	case strings.Contains(model, "haiku"):
-		inPer1M, outPer1M = 0.80, 4.00
-	case strings.Contains(model, "sonnet"):
-		inPer1M, outPer1M = 3.00, 15.00
-	case strings.Contains(model, "opus"):
-		inPer1M, outPer1M = 15.00, 75.00
-	case strings.Contains(model, "gpt-4o-mini"):
-		inPer1M, outPer1M = 0.15, 0.60
-	case strings.Contains(model, "gpt-4o"):
-		inPer1M, outPer1M = 2.50, 10.00
-	case strings.Contains(model, "o3-mini"):
-		inPer1M, outPer1M = 1.10, 4.40
-	case strings.Contains(model, "o4-mini"):
-		inPer1M, outPer1M = 1.10, 4.40
-	default:
-		return 0 // local models / unknown
+	if strings.HasSuffix(model, ":free") {
+		return 0
+	}
+	inPer1M, outPer1M := priceFor(model)
+	if inPer1M == 0 && outPer1M == 0 {
+		return 0
 	}
 	return (float64(tokensIn) * inPer1M / 1_000_000) + (float64(tokensOut) * outPer1M / 1_000_000)
+}
+
+// priceFor looks up per-1M token prices for a model. The matcher is a
+// loose substring check so versioned ids ("claude-haiku-4-5-20251001",
+// "gemini-2.5-pro-preview") fall onto the same row as the base name.
+func priceFor(model string) (in, out float64) {
+	switch {
+	// Anthropic.
+	case strings.Contains(model, "haiku"):
+		return 0.80, 4.00
+	case strings.Contains(model, "sonnet"):
+		return 3.00, 15.00
+	case strings.Contains(model, "opus"):
+		return 15.00, 75.00
+
+	// OpenAI.
+	case strings.Contains(model, "gpt-4o-mini"):
+		return 0.15, 0.60
+	case strings.Contains(model, "gpt-4o"):
+		return 2.50, 10.00
+	case strings.Contains(model, "o3-mini"), strings.Contains(model, "o4-mini"):
+		return 1.10, 4.40
+
+	// Google Gemini.
+	case strings.Contains(model, "gemini-2.5-pro"):
+		return 1.25, 10.00
+	case strings.Contains(model, "gemini-2.5-flash-lite"):
+		return 0.10, 0.40
+	case strings.Contains(model, "gemini-2.5-flash"):
+		return 0.30, 2.50
+	case strings.Contains(model, "gemini-1.5-pro"):
+		return 1.25, 5.00
+	case strings.Contains(model, "gemini-1.5-flash"):
+		return 0.075, 0.30
+
+	// Groq. Pricing scales with model family.
+	case strings.Contains(model, "llama-3.3-70b"), strings.Contains(model, "llama3-70b"):
+		return 0.59, 0.79
+	case strings.Contains(model, "llama-3.1-8b"), strings.Contains(model, "llama3-8b"):
+		return 0.05, 0.08
+	case strings.Contains(model, "mixtral"):
+		return 0.24, 0.24
+	}
+	return 0, 0
 }
 
 func formatDuration(d time.Duration) string {

--- a/tui/blocks.go
+++ b/tui/blocks.go
@@ -123,7 +123,7 @@ func toolHeader(name, detail string) string {
 	}
 	head := styleToolHead.Render(verb)
 	if detail != "" {
-		head += "  " + styleHint.Render(detail)
+		head += " " + styleHint.Render(detail)
 	}
 	return head
 }

--- a/tui/blocks.go
+++ b/tui/blocks.go
@@ -123,7 +123,7 @@ func toolHeader(name, detail string) string {
 	}
 	head := styleToolHead.Render(verb)
 	if detail != "" {
-		head += " " + styleHint.Render(detail)
+		head += "  " + styleHint.Render(detail)
 	}
 	return head
 }

--- a/tui/files.go
+++ b/tui/files.go
@@ -1,0 +1,82 @@
+package tui
+
+import (
+	"io/fs"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// fileListLimit caps how many paths the @-mention picker offers. Repos
+// with millions of files would otherwise stall the picker open.
+const fileListLimit = 2000
+
+// listProjectFiles returns paths under cwd suitable for the @-mention
+// picker. git ls-files is preferred because it already honours
+// .gitignore; the walk fallback handles non-git directories.
+func listProjectFiles(cwd string) []string {
+	if paths, ok := gitLsFiles(cwd); ok {
+		if len(paths) > fileListLimit {
+			paths = paths[:fileListLimit]
+		}
+		return paths
+	}
+	return walkProject(cwd)
+}
+
+// gitLsFiles asks git for the tracked plus untracked-not-ignored files.
+// The second return reports whether git was usable here at all.
+func gitLsFiles(cwd string) ([]string, bool) {
+	cmd := exec.Command("git", "ls-files", "--cached", "--others", "--exclude-standard")
+	cmd.Dir = cwd
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, false
+	}
+	lines := strings.Split(strings.TrimRight(string(out), "\n"), "\n")
+	if len(lines) == 1 && lines[0] == "" {
+		return nil, true
+	}
+	return lines, true
+}
+
+// walkProject is the non-git fallback. It skips common heavy directories
+// so a stray node_modules does not balloon the list.
+func walkProject(cwd string) []string {
+	skip := map[string]bool{
+		".git": true, "node_modules": true, "vendor": true,
+		"dist": true, "build": true, ".next": true, "target": true,
+	}
+	var paths []string
+	filepath.WalkDir(cwd, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if skip[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(cwd, p)
+		if err != nil {
+			return nil
+		}
+		paths = append(paths, rel)
+		if len(paths) >= fileListLimit {
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return paths
+}
+
+// fileMentionItems wraps the project file list as selector rows.
+func fileMentionItems(cwd string) []selectorItem {
+	paths := listProjectFiles(cwd)
+	items := make([]selectorItem, len(paths))
+	for i, p := range paths {
+		items[i] = selectorItem{label: p, value: p}
+	}
+	return items
+}

--- a/tui/files.go
+++ b/tui/files.go
@@ -71,12 +71,3 @@ func walkProject(cwd string) []string {
 	return paths
 }
 
-// fileMentionItems wraps the project file list as selector rows.
-func fileMentionItems(cwd string) []selectorItem {
-	paths := listProjectFiles(cwd)
-	items := make([]selectorItem, len(paths))
-	for i, p := range paths {
-		items[i] = selectorItem{label: p, value: p}
-	}
-	return items
-}

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -402,12 +402,12 @@ func isKnownSlash(text string) bool {
 // slashCommands is the canonical list, used for the /help text and the
 // type-ahead hint shown while the input starts with "/".
 var slashCommands = []struct{ name, desc string }{
-	{"/model", "list models, or switch to one"},
-	{"/config", "view config, set a key, or clear it"},
+	{"/model", "pick a model, or /model <name> to switch directly"},
+	{"/config", "open the config picker, or /config KEY value to set"},
 	{"/memory", "show what nevinho remembers about you"},
 	{"/session", "show the saved session summary"},
 	{"/status", "model, tokens, cost, approved paths"},
-	{"/paths", "list approved paths, pick one to revoke"},
+	{"/paths", "pick an approved path to revoke, or /paths clear"},
 	{"/forget", "wipe this session's history"},
 	{"/help", "show this list"},
 	{"/quit", "leave (or ctrl+c)"},

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -600,7 +600,7 @@ func (m model) workingLine() string {
 func (m model) statusBar() string {
 	left := " " + shortenHome(m.cwd)
 	if in, out, cost := m.agent.Usage(); in > 0 || out > 0 {
-		left += fmt.Sprintf("  ·  ↑%s ↓%s  $%.3f", humanCount(in), humanCount(out), cost)
+		left += fmt.Sprintf("  ·  ↑%s ↓%s  $%.2f", humanCount(in), humanCount(out), cost)
 	}
 	right := m.agent.Model() + " "
 	gap := max(m.width-lipgloss.Width(left)-lipgloss.Width(right), 1)

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -92,9 +92,14 @@ type model struct {
 	history    []string
 	historyIdx int // -1 means "not browsing", otherwise an index into history
 
-	// pendingInput is the prompt text saved while the @-mention picker
-	// is open, so cancel restores it and pick splices the path back in.
-	pendingInput string
+	// File-mention state. The picker renders above the input bar; the
+	// user keeps typing into the textarea and the text after @ becomes
+	// the filter. mentionPrefix is the input value at the moment @ was
+	// pressed, so we can splice the chosen path back in.
+	mentioning     bool
+	mentionPrefix  string
+	mentionItems   []string
+	mentionCursor  int
 }
 
 func newModel(a *agent.Agent, events chan agent.ToolEvent, cwd string) model {
@@ -202,6 +207,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.agent.Cancel(userID)
 				return m, nil
 			}
+			if m.mentioning {
+				m.mentioning = false
+				return m, nil
+			}
 			if m.configKey != "" {
 				m.configKey = ""
 				m.input.Reset()
@@ -210,6 +219,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		case "enter":
+			if m.mentioning {
+				return m.acceptMention()
+			}
 			return m.submit()
 		case "ctrl+j", "shift+enter":
 			// Insert a newline at the end of the current value and grow
@@ -222,15 +234,32 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.resizeInput()
 			return m, nil
 		case "@":
+			// Flag mention mode but let @ flow into the textarea so the
+			// user sees what they typed. The filter follows the @ in the
+			// input value.
 			if m.canMention() {
-				m.openMention()
-				return m, nil
+				m.mentioning = true
+				m.mentionPrefix = m.input.Value()
+				m.mentionItems = listProjectFiles(m.cwd)
+				m.mentionCursor = 0
 			}
 		case "up":
+			if m.mentioning {
+				if m.mentionCursor > 0 {
+					m.mentionCursor--
+				}
+				return m, nil
+			}
 			if m.historyPrev() {
 				return m, nil
 			}
 		case "down":
+			if m.mentioning {
+				if m.mentionCursor < len(m.filteredMentions())-1 {
+					m.mentionCursor++
+				}
+				return m, nil
+			}
 			if m.historyNext() {
 				return m, nil
 			}
@@ -275,6 +304,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	m.input, cmd = m.input.Update(msg)
 	m.resizeInput()
+	m.refreshMention()
 	return m, cmd
 }
 
@@ -324,14 +354,6 @@ func (m model) updateSelector(key string) (tea.Model, tea.Cmd) {
 		m.configKey = chosen
 		m.input.Reset()
 		m.input.Placeholder = "value for " + configLabels[chosen]
-	case "mention":
-		// Splice the picked path back into the prompt where the @ was
-		// typed. A trailing space lets the user keep typing without
-		// gluing the next word onto the path.
-		next := m.pendingInput + chosen + " "
-		m.pendingInput = ""
-		m.input.SetValue(next)
-		m.input.CursorEnd()
 	case "paths":
 		if m.agent.RevokePath(chosen) {
 			return m, m.printBlock(hintBlock{"revoked " + chosen})
@@ -387,11 +409,11 @@ func (m model) decideApproval(approve bool) (tea.Model, tea.Cmd) {
 	return m, tea.Batch(m.send(answer), m.spin.Tick)
 }
 
-// canMention reports whether typing @ should open the file picker. Only
+// canMention reports whether typing @ should arm the file picker. Only
 // triggers at a word boundary so paths can still contain a literal @ (an
 // email-like token mid-word stays out of the picker).
 func (m model) canMention() bool {
-	if m.busy || m.selecting || m.approving || m.configKey != "" {
+	if m.busy || m.mentioning || m.selecting || m.approving || m.configKey != "" {
 		return false
 	}
 	v := m.input.Value()
@@ -402,13 +424,64 @@ func (m model) canMention() bool {
 	return last == ' ' || last == '\n' || last == '\t'
 }
 
-// openMention saves the live prompt and opens the file picker. On pick,
-// updateSelector splices the chosen path into the saved prompt.
-func (m *model) openMention() {
-	m.pendingInput = m.input.Value()
-	m.sel = newSelector("mention a file", fileMentionItems(m.cwd))
-	m.selKind = "mention"
-	m.selecting = true
+// refreshMention checks whether the mention picker still makes sense
+// after each keystroke. If the user erased past @ or typed a space, the
+// picker closes; otherwise the cursor is clamped to the filtered list.
+func (m *model) refreshMention() {
+	if !m.mentioning {
+		return
+	}
+	v := m.input.Value()
+	want := m.mentionPrefix + "@"
+	if !strings.HasPrefix(v, want) {
+		m.mentioning = false
+		return
+	}
+	filter := v[len(want):]
+	if strings.ContainsAny(filter, " \n\t") {
+		m.mentioning = false
+		return
+	}
+	items := m.filteredMentions()
+	if m.mentionCursor >= len(items) {
+		m.mentionCursor = max(len(items)-1, 0)
+	}
+}
+
+// filteredMentions returns the project files matching the current
+// filter (the text after @ in the input).
+func (m model) filteredMentions() []string {
+	v := m.input.Value()
+	want := m.mentionPrefix + "@"
+	if !strings.HasPrefix(v, want) {
+		return m.mentionItems
+	}
+	filter := strings.ToLower(v[len(want):])
+	if filter == "" {
+		return m.mentionItems
+	}
+	out := make([]string, 0, len(m.mentionItems))
+	for _, p := range m.mentionItems {
+		if strings.Contains(strings.ToLower(p), filter) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// acceptMention splices the picked path into the prompt where @ was
+// typed, replacing the @filter span and adding a trailing space so the
+// user can keep typing without gluing the next word onto the path.
+func (m model) acceptMention() (tea.Model, tea.Cmd) {
+	items := m.filteredMentions()
+	if m.mentionCursor >= len(items) {
+		m.mentioning = false
+		return m, nil
+	}
+	m.input.SetValue(m.mentionPrefix + items[m.mentionCursor] + " ")
+	m.input.CursorEnd()
+	m.mentioning = false
+	return m, nil
 }
 
 // historyMax caps how many prompts we keep in the up/down recall ring.
@@ -694,6 +767,14 @@ func (m model) View() string {
 		m.resizeInput()
 		bottom = styleInput.Width(m.width).Render(m.input.View())
 	}
+	if m.mentioning {
+		return lipgloss.JoinVertical(lipgloss.Left,
+			"",
+			m.mentionPickerView(),
+			bottom,
+			m.statusBar(),
+		)
+	}
 	// Leading blank row keeps the live region from hugging the last
 	// printed block in scrollback.
 	return lipgloss.JoinVertical(lipgloss.Left,
@@ -702,6 +783,35 @@ func (m model) View() string {
 		bottom,
 		m.statusBar(),
 	)
+}
+
+// mentionPickerRows caps how many file rows the @-picker shows at once.
+const mentionPickerRows = 8
+
+// mentionPickerView renders the inline file list shown above the input
+// while the user is typing an @ mention. The selected row is accented;
+// the others dim, with a "+ " bullet that reads like pi's picker.
+func (m model) mentionPickerView() string {
+	items := m.filteredMentions()
+	if len(items) == 0 {
+		return styleHint.Render("  no match")
+	}
+	start := 0
+	if m.mentionCursor >= mentionPickerRows {
+		start = m.mentionCursor - mentionPickerRows + 1
+	}
+	end := min(start+mentionPickerRows, len(items))
+	var b strings.Builder
+	for i := start; i < end; i++ {
+		row := "+ " + items[i]
+		if i == m.mentionCursor {
+			b.WriteString(styleSelected.Render(row))
+		} else {
+			b.WriteString(styleHint.Render(row))
+		}
+		b.WriteString("\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
 }
 
 // approvalPicker renders the yes/no chooser shown in place of the input

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -91,6 +91,10 @@ type model struct {
 	// this list so the user can re-send or edit a recent turn.
 	history    []string
 	historyIdx int // -1 means "not browsing", otherwise an index into history
+
+	// pendingInput is the prompt text saved while the @-mention picker
+	// is open, so cancel restores it and pick splices the path back in.
+	pendingInput string
 }
 
 func newModel(a *agent.Agent, events chan agent.ToolEvent, cwd string) model {
@@ -217,6 +221,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.input.CursorEnd()
 			m.resizeInput()
 			return m, nil
+		case "@":
+			if m.canMention() {
+				m.openMention()
+				return m, nil
+			}
 		case "up":
 			if m.historyPrev() {
 				return m, nil
@@ -315,6 +324,14 @@ func (m model) updateSelector(key string) (tea.Model, tea.Cmd) {
 		m.configKey = chosen
 		m.input.Reset()
 		m.input.Placeholder = "value for " + configLabels[chosen]
+	case "mention":
+		// Splice the picked path back into the prompt where the @ was
+		// typed. A trailing space lets the user keep typing without
+		// gluing the next word onto the path.
+		next := m.pendingInput + chosen + " "
+		m.pendingInput = ""
+		m.input.SetValue(next)
+		m.input.CursorEnd()
 	case "paths":
 		if m.agent.RevokePath(chosen) {
 			return m, m.printBlock(hintBlock{"revoked " + chosen})
@@ -368,6 +385,30 @@ func (m model) decideApproval(approve bool) (tea.Model, tea.Cmd) {
 	}
 	m.busy = true
 	return m, tea.Batch(m.send(answer), m.spin.Tick)
+}
+
+// canMention reports whether typing @ should open the file picker. Only
+// triggers at a word boundary so paths can still contain a literal @ (an
+// email-like token mid-word stays out of the picker).
+func (m model) canMention() bool {
+	if m.busy || m.selecting || m.approving || m.configKey != "" {
+		return false
+	}
+	v := m.input.Value()
+	if v == "" {
+		return true
+	}
+	last := v[len(v)-1]
+	return last == ' ' || last == '\n' || last == '\t'
+}
+
+// openMention saves the live prompt and opens the file picker. On pick,
+// updateSelector splices the chosen path into the saved prompt.
+func (m *model) openMention() {
+	m.pendingInput = m.input.Value()
+	m.sel = newSelector("mention a file", fileMentionItems(m.cwd))
+	m.selKind = "mention"
+	m.selecting = true
 }
 
 // historyMax caps how many prompts we keep in the up/down recall ring.

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -360,8 +360,15 @@ func (m model) submit() (tea.Model, tea.Cmd) {
 	}
 	m.input.Reset()
 	if cmd, handled := m.handleSlash(text); handled {
-		// Echo the command into scrollback so the transcript shows what
-		// the user typed, same as a normal turn.
+		// Echo known commands so the transcript shows what the user
+		// typed, same as a normal turn. Typos go straight to the hint
+		// without a user bubble.
+		if !isKnownSlash(text) {
+			if cmd == nil {
+				return m, nil
+			}
+			return m, cmd
+		}
 		echo := m.printBlock(userBlock{text})
 		if cmd == nil {
 			return m, echo
@@ -374,6 +381,22 @@ func (m model) submit() (tea.Model, tea.Cmd) {
 		m.send(text),
 		m.spin.Tick,
 	)
+}
+
+// isKnownSlash reports whether the leading word of text matches one of
+// the registered slash commands. Used to gate the user-bubble echo so
+// typos do not leave a stray transcript entry.
+func isKnownSlash(text string) bool {
+	cmd, _, _ := strings.Cut(strings.TrimSpace(text), " ")
+	if cmd == "/q" {
+		return true
+	}
+	for _, c := range slashCommands {
+		if cmd == c.name {
+			return true
+		}
+	}
+	return false
 }
 
 // slashCommands is the canonical list, used for the /help text and the

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -86,6 +86,11 @@ type model struct {
 	width          int
 	height         int
 	ready          bool
+
+	// Submitted prompts, newest last. Up/down on an empty input walks
+	// this list so the user can re-send or edit a recent turn.
+	history    []string
+	historyIdx int // -1 means "not browsing", otherwise an index into history
 }
 
 func newModel(a *agent.Agent, events chan agent.ToolEvent, cwd string) model {
@@ -103,11 +108,12 @@ func newModel(a *agent.Agent, events chan agent.ToolEvent, cwd string) model {
 	sp.Style = styleSpin
 
 	return model{
-		agent:  a,
-		events: events,
-		cwd:    cwd,
-		input:  ta,
-		spin:   sp,
+		agent:      a,
+		events:     events,
+		cwd:        cwd,
+		input:      ta,
+		spin:       sp,
+		historyIdx: -1,
 	}
 }
 
@@ -201,6 +207,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case "enter":
 			return m.submit()
+		case "up":
+			if m.historyPrev() {
+				return m, nil
+			}
+		case "down":
+			if m.historyNext() {
+				return m, nil
+			}
 		}
 
 	case responseMsg:
@@ -333,6 +347,67 @@ func (m model) decideApproval(approve bool) (tea.Model, tea.Cmd) {
 	return m, tea.Batch(m.send(answer), m.spin.Tick)
 }
 
+// historyMax caps how many prompts we keep in the up/down recall ring.
+const historyMax = 100
+
+// recordHistory appends a submitted prompt to the recall ring. Duplicates
+// of the most recent entry are skipped so up-arrow lands on a new line
+// instead of the same one twice in a row.
+func (m *model) recordHistory(text string) {
+	if n := len(m.history); n > 0 && m.history[n-1] == text {
+		m.historyIdx = -1
+		return
+	}
+	m.history = append(m.history, text)
+	if len(m.history) > historyMax {
+		m.history = m.history[len(m.history)-historyMax:]
+	}
+	m.historyIdx = -1
+}
+
+// historyPrev loads the previous submitted prompt into the input. Returns
+// false when there is nothing earlier to load, so the caller can let the
+// keypress fall through to the textarea (which moves the cursor up).
+func (m *model) historyPrev() bool {
+	if len(m.history) == 0 {
+		return false
+	}
+	// Only intercept when the user is not mid-edit, so up-arrow inside a
+	// long pasted prompt still moves the textarea cursor.
+	if m.historyIdx == -1 && strings.TrimSpace(m.input.Value()) != "" {
+		return false
+	}
+	next := m.historyIdx - 1
+	if m.historyIdx == -1 {
+		next = len(m.history) - 1
+	}
+	if next < 0 {
+		return true // already at the oldest, swallow the keypress
+	}
+	m.historyIdx = next
+	m.input.SetValue(m.history[next])
+	m.input.CursorEnd()
+	return true
+}
+
+// historyNext walks forward through recall toward the live empty input.
+// At the newest entry one more press clears the input and exits recall.
+func (m *model) historyNext() bool {
+	if m.historyIdx == -1 {
+		return false
+	}
+	next := m.historyIdx + 1
+	if next >= len(m.history) {
+		m.historyIdx = -1
+		m.input.Reset()
+		return true
+	}
+	m.historyIdx = next
+	m.input.SetValue(m.history[next])
+	m.input.CursorEnd()
+	return true
+}
+
 // submit sends the current input to the agent, or runs it as a slash command.
 func (m model) submit() (tea.Model, tea.Cmd) {
 	if m.busy {
@@ -358,6 +433,7 @@ func (m model) submit() (tea.Model, tea.Cmd) {
 	if text == "" {
 		return m, nil
 	}
+	m.recordHistory(text)
 	m.input.Reset()
 	if cmd, handled := m.handleSlash(text); handled {
 		// Echo known commands so the transcript shows what the user

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -207,6 +207,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case "enter":
 			return m.submit()
+		case "ctrl+j", "shift+enter":
+			// Insert a newline at the end of the current value and grow
+			// the textarea so the user can compose a multi-paragraph
+			// prompt before pressing enter to send. Most terminals only
+			// emit shift+enter when the kitty keyboard protocol is on,
+			// so ctrl+j is the portable fallback.
+			m.input.SetValue(m.input.Value() + "\n")
+			m.input.CursorEnd()
+			m.resizeInput()
+			return m, nil
 		case "up":
 			if m.historyPrev() {
 				return m, nil
@@ -255,7 +265,20 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	var cmd tea.Cmd
 	m.input, cmd = m.input.Update(msg)
+	m.resizeInput()
 	return m, cmd
+}
+
+// inputMaxRows caps how tall the input grows. Past this the textarea
+// scrolls inside its own box rather than pushing the live region up.
+const inputMaxRows = 6
+
+// resizeInput keeps the textarea height in sync with its content. A
+// single-line prompt stays compact, a paste or ctrl+j grows it up to
+// inputMaxRows so the user sees what they typed.
+func (m *model) resizeInput() {
+	rows := min(max(strings.Count(m.input.Value(), "\n")+1, 1), inputMaxRows)
+	m.input.SetHeight(rows)
 }
 
 // updateSelector handles one keypress while a picker is open. A non-empty
@@ -625,6 +648,9 @@ func (m model) View() string {
 		bottom = m.approvalPicker()
 	} else {
 		// Hairline bar spans the full terminal width like pi's input row.
+		// resizeInput keeps the height honest after Reset/SetValue paths
+		// that ran outside the keystroke loop.
+		m.resizeInput()
 		bottom = styleInput.Width(m.width).Render(m.input.View())
 	}
 	// Leading blank row keeps the live region from hugging the last


### PR DESCRIPTION
## What

A pass over the terminal client to make daily coding-agent use less frictionful. Adds `@file` mentions, prompt history recall, multi-line input, and real cost numbers for the providers most people actually use.

## Changes

- `@file` picker: type `@` at a word boundary to open a filterable list of project paths (git ls-files, walk fallback). Picked path is spliced into the prompt; cancel restores the input untouched.
- Prompt history: up/down arrows recall prior submitted prompts. 100-entry ring, dedupes against the previous entry. Only intercepts when the input is empty so cursor movement in mid-edit still works.
- Multi-line input: ctrl+j inserts a newline and grows the textarea up to 6 rows. shift+enter is bound for terminals running the kitty keyboard protocol.
- Cost tracking now covers Gemini (2.5 pro/flash/lite, 1.5), Groq (llama 3.1/3.3, mixtral), and explicitly zeroes OpenRouter `:free` variants. The status bar stops showing `$0.000` for non-Anthropic/OpenAI sessions.
- Unknown slash commands no longer leave a stray user bubble in scrollback; the hint fires directly.
- `/help` mentions subcommand syntax (`/model <name>`, `/config KEY value`, `/paths clear`).
- Status bar cost rounded to two decimals.

Roadmap updated: this work moves into Shipped, and a "Terminal UI follow-ups" section captures the remaining rough edges (API key masking, slash autocomplete, tool card expand, `/diff`, `/cd`, session list).