### PR TITLE
fix(tools): bound find walks and silence permission noise

### DIFF
--- a/tools/find.go
+++ b/tools/find.go
@@ -4,20 +4,26 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
 
-const findDefaultLimit = 500
+const (
+	findDefaultLimit    = 500
+	findDefaultMaxDepth = 8
+)
 
 type findInput struct {
-	Pattern string `json:"pattern"`
-	Path    string `json:"path"`
-	Type    string `json:"type"`
-	Limit   int    `json:"limit"`
+	Pattern  string `json:"pattern"`
+	Path     string `json:"path"`
+	Type     string `json:"type"`
+	Limit    int    `json:"limit"`
+	MaxDepth int    `json:"max_depth"`
 }
 
 func (r *Registry) findFiles(ctx context.Context, input json.RawMessage, userID string) string {
@@ -47,21 +53,33 @@ func (r *Registry) findFiles(ctx context.Context, input json.RawMessage, userID 
 		findType = "d"
 	}
 
+	maxDepth := in.MaxDepth
+	if maxDepth <= 0 {
+		maxDepth = findDefaultMaxDepth
+	}
+
 	args := []string{
 		resolved,
+		"-maxdepth", strconv.Itoa(maxDepth),
 		"-type", findType,
-		"-name", in.Pattern,
+		"-iname", in.Pattern,
 		"-not", "-path", "*/.git/*",
 		"-not", "-path", "*/node_modules/*",
 		"-not", "-path", "*/__pycache__/*",
 		"-not", "-path", "*/.venv/*",
+		"-not", "-path", "*/Library/*",
+		"-not", "-path", "*/.Trash/*",
+		"-not", "-path", "*/.cache/*",
 	}
 
 	tctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
+	// Discard stderr so permission-denied noise from system trees does not
+	// leak into the result the model has to read.
 	cmd := exec.CommandContext(tctx, "find", args...)
-	output, err := cmd.CombinedOutput()
+	cmd.Stderr = io.Discard
+	output, err := cmd.Output()
 	result := strings.TrimRight(string(output), "\n")
 
 	if err != nil {

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -241,19 +241,21 @@ Errors (literal prefixes):
 		},
 		{
 			Name: "find",
-			Description: `Find files or directories by name pattern (shell glob). Excludes .git, node_modules, __pycache__, .venv.
+			Description: `Find files or directories by name pattern (shell glob). Case-insensitive. Excludes .git, node_modules, __pycache__, .venv, Library, .Trash, .cache.
 Rules:
-- Default search root is the current working directory. Only pass path when the user explicitly references a different location (e.g. "in ~/apps").
+- Default search root is the current working directory. Only pass path when the user explicitly references a different location (e.g. "in ~/apps", "under ~/dev").
+- Never search from "/". Start from $HOME or a known subtree. Walking the whole filesystem times out.
 - Use type="d" for directories, "f" (default) for files.
+- Default max_depth is 8. Raise it only when a project is known to be deeply nested.
 - Default limit is 500.
 - To list a directory, use file_list. find is for locating specific names.
 Output: one relative path per line. Appends "[<N> results limit reached. Use limit=<M> for more, or refine pattern]" when capped.
 Errors (literal prefixes):
 - "invalid input: ...", "invalid path: ...", "pattern is required ...".
-- "no files found matching pattern" pattern did not hit.
-- "find timed out after 30s ..." narrow the path or pattern.
+- "no files found matching pattern" pattern did not hit. Try a broader path or a wildcarded pattern like "*name*".
+- "find timed out after 30s ..." narrow the path, lower max_depth, or refine pattern.
 - "find failed: ..." other error.`,
-			Schema: `{"type":"object","properties":{"pattern":{"type":"string","description":"Glob pattern, e.g. \"*.go\", \"Makefile\", \"myproject\""},"path":{"type":"string","description":"Directory to search in (defaults to current directory)"},"type":{"type":"string","description":"Type: \"f\" for files (default), \"d\" for directories"},"limit":{"type":"integer","description":"Max results (default 500)"}},"required":["pattern"]}`,
+			Schema: `{"type":"object","properties":{"pattern":{"type":"string","description":"Glob pattern, e.g. \"*.go\", \"Makefile\", \"nevinho\". Case-insensitive."},"path":{"type":"string","description":"Directory to search in (defaults to current directory). Prefer narrow roots like ~/dev over $HOME."},"type":{"type":"string","description":"Type: \"f\" for files (default), \"d\" for directories"},"max_depth":{"type":"integer","description":"Max directory depth to walk (default 8)"},"limit":{"type":"integer","description":"Max results (default 500)"}},"required":["pattern"]}`,
 		},
 		{
 			Name: "schedule",


### PR DESCRIPTION
## What

`find` could time out when rooted at a broad path like `/` or `$HOME` because the walk was unbounded and the BSD `find` permission-denied stderr was mixed into the result. The model also tended to pass overly broad roots because the description did not warn against it.

## Changes

- Add `max_depth` param to the find tool, default 8.
- Switch `-name` to `-iname` so casing differences do not cause empty results.
- Prune `Library`, `.Trash`, `.cache` in addition to the existing four.
- Discard stderr so permission errors do not pollute output.
- Update tool description: never search from `/`, prefer narrow roots, advertise `max_depth`.