### PR TITLE
feat(tools): capability-scoped execution contexts

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -94,13 +94,17 @@ The TUI is the primary surface when nevinho is used as a coding agent. After the
 
 ### Scheduled tasks: follow-ups
 
-Foundation shipped. Remaining work:
+Foundation shipped. Capability-scoped execution contexts (PR #64) replaced the brittle approval-needs-a-human path: scheduled fires now run with a read-only tool set (`web_read`, `web_search`, `file_read`, `file_list`, `grep`, `find`) and cannot deadlock on approval. Remaining work, in priority order:
 
-- [ ] `pause` / `resume` actions on the agent tool.
-- [ ] `/schedules` Discord command (slash + plain text).
-- [ ] Non-interactive bash allowlist mode during scheduled runs so safe commands (read-only) can complete without an approval prompt.
-- [ ] `last_run` and `next_run` exposed in `/status`.
-- [ ] Surface failed-run history (last N errors per schedule).
+- [ ] **TUI scheduler.** `nevinho chat` does not start a runner today, so schedules created from the terminal never fire. Wire `startScheduler` into `cmd/chat.go` behind a flag (or always, but cleanly stop on exit). Decide where results land when the TUI is the origin: stream into the active session if one is open, otherwise queue and replay on next launch.
+- [ ] **Transport-aware notify.** Schedule carries no `Origin` today, so `notifyFn` hardcodes Discord owner DM. Add `Origin` (`discord` | `slack` | `telegram` | `tui`) at create time and route notify by origin. Slack/Telegram transports already in scope of `transport/` interface refactor (see Later).
+- [ ] **`run_now` action.** Lets the user test a schedule immediately instead of waiting for the next cron window. Implement as a buffered channel on `Runner` that the Store signals via a callback set on `Runner.Start`.
+- [ ] **Human-readable cron.** `/schedules` and the create response should show "Daily at 18:00 (Europe/Paris)" instead of "0 18 * * *". Small lookup that handles the common shapes (`@daily`, `@every Xh`, `0 H * * *`, `0 H * * 1-5`, etc.) and falls back to the raw expression.
+- [ ] **Retry on transient failures.** Classify 5xx, timeouts, and rate limits inside `safeRun`. Retry twice with backoff (30s / 2m) before declaring a run failed and sending the failure DM.
+- [ ] **`pause` / `resume`** actions on the agent tool.
+- [ ] **`/schedules`** Discord slash command (in addition to the existing plain-text variant).
+- [ ] **`last_run` and `next_run`** exposed in `/status`.
+- [ ] **Failed-run history** surfaced in the schedule tool (last N errors per schedule).
 
 ## Later
 

--- a/agent/loop.go
+++ b/agent/loop.go
@@ -16,11 +16,27 @@ import (
 )
 
 func (a *Agent) Chat(userID, text string, isVoice bool, images []llm.Image) (string, error) {
+	return a.chat(userID, text, isVoice, images, tools.SourceInteractive)
+}
+
+// ChatScheduled is the entry point the schedule runner uses. It tags the
+// turn with SourceScheduled so the tool registry filters out shell and
+// write tools and the dispatch layer refuses them by capability.
+func (a *Agent) ChatScheduled(userID, prompt string) (string, error) {
+	return a.chat(userID, prompt, false, nil, tools.SourceScheduled)
+}
+
+func (a *Agent) chat(userID, text string, isVoice bool, images []llm.Image, source tools.Source) (string, error) {
 	lock := a.getUserLock(userID)
 	lock.Lock()
 	defer lock.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), chatTimeout)
+	ctx = tools.WithExecContext(ctx, tools.ExecContext{
+		Source: source,
+		Caps:   tools.DefaultCaps[source],
+		UserID: userID,
+	})
 	a.mu.Lock()
 	a.cancelFn[userID] = cancel
 	a.mu.Unlock()
@@ -108,7 +124,7 @@ func (a *Agent) Chat(userID, text string, isVoice bool, images []llm.Image) (str
 		resp, err := a.llm.Complete(ctx, &llm.Request{
 			SystemPrompt: prompt,
 			Messages:     a.history[userID],
-			Tools:        a.tools.Defs(),
+			Tools:        a.tools.DefsFor(ctx),
 			MaxTokens:    maxOutputTokens,
 		})
 		if err != nil {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -94,7 +94,7 @@ func startScheduler(a *agent.Agent, bot *discord.Bot, configDir string) (*schedu
 		// Chat manages its own per-call timeout. The ctx here is the
 		// runner's deadline, used by future agent paths that accept it.
 		_ = ctx
-		return a.Chat(userID, prompt, false, nil)
+		return a.ChatScheduled(userID, prompt)
 	}
 
 	notifyFn := func(s schedule.Schedule, result string, err error) {

--- a/tools/capabilities.go
+++ b/tools/capabilities.go
@@ -1,0 +1,82 @@
+package tools
+
+import "context"
+
+// Capability is a coarse permission a tool needs to run. Tools tag
+// themselves with one. Execution contexts grant a set. The registry
+// only dispatches a tool whose capability is in the granting set.
+type Capability string
+
+const (
+	CapNetRead     Capability = "net.read"
+	CapFSRead      Capability = "fs.read"
+	CapFSWrite     Capability = "fs.write"
+	CapShellExec   Capability = "shell.exec"
+	CapScheduleMut Capability = "schedule.mut"
+)
+
+// Source describes where a turn originated. Each source maps to a
+// default capability preset via DefaultCaps.
+type Source string
+
+const (
+	SourceInteractive Source = "interactive"
+	SourceScheduled   Source = "scheduled"
+)
+
+// CapSet is an unordered set of capabilities. The zero value behaves as
+// the empty set, so checking with Has on a nil set is safe.
+type CapSet map[Capability]struct{}
+
+// NewCapSet builds a set from the given capabilities.
+func NewCapSet(caps ...Capability) CapSet {
+	s := make(CapSet, len(caps))
+	for _, c := range caps {
+		s[c] = struct{}{}
+	}
+	return s
+}
+
+// Has reports whether the set contains c.
+func (s CapSet) Has(c Capability) bool {
+	_, ok := s[c]
+	return ok
+}
+
+// DefaultCaps maps each Source to its capability preset. Scheduled
+// runs are read-only by design: no shell, no writes, no schedule
+// mutation (so a fire cannot create more schedules).
+var DefaultCaps = map[Source]CapSet{
+	SourceInteractive: NewCapSet(CapNetRead, CapFSRead, CapFSWrite, CapShellExec, CapScheduleMut),
+	SourceScheduled:   NewCapSet(CapNetRead, CapFSRead),
+}
+
+// ExecContext travels with a turn through context.Context. Tools and
+// the registry read it to decide what is permitted.
+type ExecContext struct {
+	Source Source
+	Caps   CapSet
+	UserID string
+}
+
+type execContextKey struct{}
+
+// WithExecContext attaches ec to ctx so downstream tools and the
+// registry can read it via ExecContextOf.
+func WithExecContext(ctx context.Context, ec ExecContext) context.Context {
+	return context.WithValue(ctx, execContextKey{}, ec)
+}
+
+// ExecContextOf returns the ExecContext attached to ctx. When none is
+// attached it returns the interactive preset, which keeps existing
+// direct callers (tests, ad-hoc tool invocations) working without
+// having to know about contexts.
+func ExecContextOf(ctx context.Context) ExecContext {
+	if ec, ok := ctx.Value(execContextKey{}).(ExecContext); ok {
+		return ec
+	}
+	return ExecContext{
+		Source: SourceInteractive,
+		Caps:   DefaultCaps[SourceInteractive],
+	}
+}

--- a/tools/capabilities_test.go
+++ b/tools/capabilities_test.go
@@ -1,0 +1,96 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestExecContextOfDefaultsToInteractive(t *testing.T) {
+	ec := ExecContextOf(context.Background())
+	if ec.Source != SourceInteractive {
+		t.Fatalf("default source = %q, want %q", ec.Source, SourceInteractive)
+	}
+	for _, cap := range []Capability{CapNetRead, CapFSRead, CapFSWrite, CapShellExec, CapScheduleMut} {
+		if !ec.Caps.Has(cap) {
+			t.Errorf("interactive default missing %q", cap)
+		}
+	}
+}
+
+func TestWithExecContextRoundTrip(t *testing.T) {
+	want := ExecContext{
+		Source: SourceScheduled,
+		Caps:   DefaultCaps[SourceScheduled],
+		UserID: "scheduler:abc",
+	}
+	ctx := WithExecContext(context.Background(), want)
+	got := ExecContextOf(ctx)
+
+	if got.Source != want.Source || got.UserID != want.UserID {
+		t.Fatalf("round trip lost fields: %+v vs %+v", got, want)
+	}
+	if got.Caps.Has(CapShellExec) {
+		t.Error("scheduled context must not grant shell.exec")
+	}
+	if !got.Caps.Has(CapNetRead) {
+		t.Error("scheduled context must grant net.read")
+	}
+}
+
+func TestScheduledContextHidesShellAndWriteTools(t *testing.T) {
+	r, _ := newTestRegistry(t)
+
+	ctx := WithExecContext(context.Background(), ExecContext{
+		Source: SourceScheduled,
+		Caps:   DefaultCaps[SourceScheduled],
+	})
+	defs := r.DefsFor(ctx)
+
+	got := make(map[string]bool, len(defs))
+	for _, d := range defs {
+		got[d.Name] = true
+	}
+
+	mustHave := []string{"web_read", "web_search", "file_read", "file_list", "grep", "find"}
+	mustHide := []string{"bash", "file_write", "file_edit", "schedule"}
+
+	for _, name := range mustHave {
+		if !got[name] {
+			t.Errorf("scheduled DefsFor missing read-only tool %q", name)
+		}
+	}
+	for _, name := range mustHide {
+		if got[name] {
+			t.Errorf("scheduled DefsFor leaks privileged tool %q", name)
+		}
+	}
+}
+
+func TestInteractiveContextExposesEveryTool(t *testing.T) {
+	r, _ := newTestRegistry(t)
+
+	defs := r.DefsFor(context.Background()) // default = interactive
+	if len(defs) != len(r.Defs()) {
+		t.Fatalf("interactive DefsFor returned %d defs, want all %d", len(defs), len(r.Defs()))
+	}
+}
+
+func TestExecuteBlocksOnMissingCapability(t *testing.T) {
+	r, _ := newTestRegistry(t)
+
+	ctx := WithExecContext(context.Background(), ExecContext{
+		Source: SourceScheduled,
+		Caps:   DefaultCaps[SourceScheduled],
+	})
+	input, _ := json.Marshal(map[string]any{"command": "echo hi"})
+	out := r.Execute(ctx, "bash", input, "scheduler:abc")
+
+	if !strings.HasPrefix(out, "blocked:") {
+		t.Fatalf("expected capability block, got: %q", out)
+	}
+	if !strings.Contains(out, string(CapShellExec)) {
+		t.Errorf("block message should name the missing capability, got: %q", out)
+	}
+}

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -83,6 +83,13 @@ func (r *Registry) isStrict() bool {
 }
 
 func (r *Registry) Execute(ctx context.Context, name string, input json.RawMessage, userID string) string {
+	if req := requirementFor(name); req != "" {
+		ec := ExecContextOf(ctx)
+		if !ec.Caps.Has(req) {
+			return fmt.Sprintf("blocked: tool %q requires capability %q, not granted in %s context",
+				name, req, ec.Source)
+		}
+	}
 	switch name {
 	case "web_read":
 		return r.webRead(input)
@@ -262,7 +269,11 @@ Errors (literal prefixes):
 			Description: `Manage recurring prompts that nevinho runs on a cron timetable.
 Use to set up "every morning at 9 summarize hacker news", "every Monday list my open PRs", etc.
 Translate the user's natural language into a cron expression yourself. Do not ask the user to write cron.
-Schedules run without an interactive approval prompt, so refuse to create schedules whose prompts would normally need approval (destructive bash, file writes outside approved paths). Suggest a safer prompt instead.
+
+Prompt rules:
+- The "prompt" field must be a natural-language instruction (e.g. "Fetch the top 5 Hacker News stories and reply with a bulleted list of titles and links"). Not shell, not code. The agent picks tools fresh on every fire.
+- Scheduled fires run with read-only capabilities: web_read, web_search, file_read, file_list, grep, find. Bash, file writes, and creating more schedules are not available. If a user request needs those, suggest a safer phrasing instead.
+
 Cron accepts standard 5-field expressions ("0 9 * * *"), descriptors (@daily, @hourly, @weekly), and durations (@every 30m, @every 6h). Minimum interval is 5 minutes. Maximum 10 schedules total.
 Timezones: pass an IANA name (e.g. "Europe/Paris", "America/New_York") via the timezone argument when the user mentions a city or zone. The cron expression is then evaluated in that timezone. Without a timezone, the server's local time is used.
 Actions:
@@ -276,6 +287,43 @@ Output: human readable text. Errors are prefixed with "failed: " or "invalid inp
 			Schema: `{"type":"object","properties":{"action":{"type":"string","enum":["list","create","delete","pause","resume","logs"],"description":"Action to perform"},"name":{"type":"string","description":"Unique schedule name. Required for create, delete, pause, resume, and logs."},"cron":{"type":"string","description":"Cron expression. Required for create. Examples: \"0 9 * * *\", \"@daily\", \"@every 30m\"."},"prompt":{"type":"string","description":"What nevinho should run on each fire. Required for create."},"timezone":{"type":"string","description":"Optional IANA timezone (e.g. \"Europe/Paris\"). When set, the cron is evaluated in this zone."}},"required":["action"]}`,
 		},
 	}
+}
+
+// requirementFor returns the capability a named tool needs to run, or
+// "" when a tool is always permitted. This is the single source of
+// truth for tool capabilities; DefsFor and Execute both consult it.
+// Keep it in sync when adding or renaming tools.
+func requirementFor(name string) Capability {
+	switch name {
+	case "web_read", "web_search":
+		return CapNetRead
+	case "bash":
+		return CapShellExec
+	case "file_read", "file_list", "grep", "find":
+		return CapFSRead
+	case "file_write", "file_edit":
+		return CapFSWrite
+	case "schedule":
+		return CapScheduleMut
+	}
+	return ""
+}
+
+// DefsFor returns the tool definitions available under the ExecContext
+// attached to ctx. Tools whose required capability is not granted are
+// filtered out so the model does not even see them. This is the
+// primary safety mechanism; Execute also re-checks at dispatch.
+func (r *Registry) DefsFor(ctx context.Context) []llm.ToolDef {
+	ec := ExecContextOf(ctx)
+	all := r.Defs()
+	out := make([]llm.ToolDef, 0, len(all))
+	for _, d := range all {
+		req := requirementFor(d.Name)
+		if req == "" || ec.Caps.Has(req) {
+			out = append(out, d)
+		}
+	}
+	return out
 }
 
 func (r *Registry) ApprovedPaths() []string {


### PR DESCRIPTION
## What

Scheduled fires deadlocked on approval because the agent could emit shell or write tool calls with no human present. Replaced the existing prefix-sniffing block with a proper capability model: tools declare what they require, execution contexts grant a capability set, the registry filters at the LLM boundary and rechecks at dispatch. No prompt-engineered safety.

Interactive flow is unchanged. Scheduled fires now see only read-only tools (`web_read`, `web_search`, `file_read`, `file_list`, `grep`, `find`). The model cannot emit `bash`, `file_write`, `file_edit`, or `schedule` calls because they are not in its tool list.

## Changes

- New `tools/capabilities.go`: `Capability`, `Source`, `CapSet`, `ExecContext`, `DefaultCaps`, and `WithExecContext`/`ExecContextOf` plumbing on `context.Context`.
- `tools/registry.go`: `requirementFor(name)` switch maps tool to capability; `DefsFor(ctx)` filters tool list; `Execute(ctx, ...)` re-checks at dispatch. Schedule tool description rewritten to match the new reality.
- `agent/loop.go`: `Chat` and new `ChatScheduled` both call private `chat(...)` which attaches the right `ExecContext` to ctx. `DefsFor(ctx)` replaces `Defs()` per turn.
- `cmd/serve.go`: schedule runner calls `a.ChatScheduled` instead of `a.Chat`.
- `tools/capabilities_test.go`: covers default fallback, round-trip, scheduled filter, interactive full set, dispatch-time block.

## Removed

- `IsScheduledUser`, `ScheduledUserID`, and the `scheduler:` prefix constant in `tools/registry.go`.
- Scheduled-context if-blocks in `tools/bash.go` and `checkWritePermission`.