### PR TITLE
feat(tui): stream assistant responses

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -89,6 +89,7 @@ The TUI is the primary surface when nevinho is used as a coding agent. After the
 - [ ] Slash-command autocomplete picker. The inline hint shows matching names; a real picker on `/` would let the user pick instead of finishing the word.
 - [ ] Tool card expand. Print the full output of the previous tool call without tailing `chat.log`. Either a `/last` command or a keystroke on the last card.
 - [ ] `/diff` to show pending `file_edit` and `file_write` changes the agent staged but the user has not approved.
+- [ ] Response time in the TUI. Surface the last turn duration directly in the terminal UI, likely in the status bar or final assistant block metadata. Start with total turn duration using the existing `logger.Done` timing path; later split out time-to-first-token if streaming latency becomes important.
 - [ ] `/cd <path>` to change the agent's working directory without restarting nevinho.
 - [ ] Session list and `/load <id>` to resume a past saved summary instead of starting cold.
 

--- a/agent/loop.go
+++ b/agent/loop.go
@@ -16,7 +16,11 @@ import (
 )
 
 func (a *Agent) Chat(userID, text string, isVoice bool, images []llm.Image) (string, error) {
-	return a.chat(userID, text, isVoice, images, tools.SourceInteractive)
+	return a.chat(userID, text, isVoice, images, tools.SourceInteractive, nil)
+}
+
+func (a *Agent) ChatStream(userID, text string, isVoice bool, images []llm.Image, cb llm.StreamCallback) (string, error) {
+	return a.chat(userID, text, isVoice, images, tools.SourceInteractive, cb)
 }
 
 // ChatScheduled is the entry point the schedule runner uses. It tags the
@@ -30,10 +34,10 @@ func (a *Agent) Chat(userID, text string, isVoice bool, images []llm.Image) (str
 // preceding user/functionResponse turn.
 func (a *Agent) ChatScheduled(userID, prompt string) (string, error) {
 	a.ClearHistory(userID)
-	return a.chat(userID, prompt, false, nil, tools.SourceScheduled)
+	return a.chat(userID, prompt, false, nil, tools.SourceScheduled, nil)
 }
 
-func (a *Agent) chat(userID, text string, isVoice bool, images []llm.Image, source tools.Source) (string, error) {
+func (a *Agent) chat(userID, text string, isVoice bool, images []llm.Image, source tools.Source, streamCb llm.StreamCallback) (string, error) {
 	lock := a.getUserLock(userID)
 	lock.Lock()
 	defer lock.Unlock()
@@ -128,12 +132,23 @@ func (a *Agent) chat(userID, text string, isVoice bool, images []llm.Image, sour
 		if ctx.Err() != nil {
 			return "Cancelled.", nil
 		}
-		resp, err := a.llm.Complete(ctx, &llm.Request{
+		req := &llm.Request{
 			SystemPrompt: prompt,
 			Messages:     a.history[userID],
 			Tools:        a.tools.DefsFor(ctx),
 			MaxTokens:    maxOutputTokens,
-		})
+		}
+		var resp *llm.Response
+		var err error
+		if streamCb != nil {
+			if sp, ok := a.llm.(llm.StreamingProvider); ok {
+				resp, err = sp.StreamComplete(ctx, req, streamCb)
+			} else {
+				resp, err = a.llm.Complete(ctx, req)
+			}
+		} else {
+			resp, err = a.llm.Complete(ctx, req)
+		}
 		if err != nil {
 			logger.Err(err)
 			return "", err

--- a/agent/stream_test.go
+++ b/agent/stream_test.go
@@ -26,6 +26,39 @@ func (p *fallbackProvider) ReplaceToolResult(history []json.RawMessage, toolUseI
 }
 func (p *fallbackProvider) Model() string { return "fake" }
 
+type optInStreamingProvider struct {
+	completeCalls int
+	streamCalls   int
+}
+
+func (p *optInStreamingProvider) Complete(ctx context.Context, req *llm.Request) (*llm.Response, error) {
+	p.completeCalls++
+	msg, _ := json.Marshal(map[string]any{"role": "assistant", "content": "complete ok"})
+	return &llm.Response{Text: "complete ok", AssistantMessage: msg, StopReason: llm.StopEndTurn}, nil
+}
+
+func (p *optInStreamingProvider) StreamComplete(ctx context.Context, req *llm.Request, cb llm.StreamCallback) (*llm.Response, error) {
+	p.streamCalls++
+	if cb != nil {
+		cb("stream")
+		cb(" ok")
+	}
+	msg, _ := json.Marshal(map[string]any{"role": "assistant", "content": "stream ok"})
+	return &llm.Response{Text: "stream ok", AssistantMessage: msg, StopReason: llm.StopEndTurn}, nil
+}
+
+func (p *optInStreamingProvider) FormatUserMessage(text string, images []llm.Image) json.RawMessage {
+	msg, _ := json.Marshal(map[string]any{"role": "user", "content": text})
+	return msg
+}
+func (p *optInStreamingProvider) FormatToolResults(results []llm.ToolResult) []json.RawMessage {
+	return nil
+}
+func (p *optInStreamingProvider) ReplaceToolResult(history []json.RawMessage, toolUseID, newOutput string) []json.RawMessage {
+	return history
+}
+func (p *optInStreamingProvider) Model() string { return "fake" }
+
 func TestChatStreamFallsBackToComplete(t *testing.T) {
 	p := &fallbackProvider{}
 	cfg, err := config.Load(t.TempDir())
@@ -46,5 +79,46 @@ func TestChatStreamFallsBackToComplete(t *testing.T) {
 	}
 	if streamed {
 		t.Fatal("stream callback should not run for fallback provider")
+	}
+}
+
+func TestChatDoesNotStreamUnlessCallerOptsIn(t *testing.T) {
+	p := &optInStreamingProvider{}
+	cfg, err := config.Load(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := New(p, cfg, "test", "", ModeLocal)
+
+	got, err := a.Chat("u", "hello", false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "complete ok" {
+		t.Fatalf("got %q, want complete ok", got)
+	}
+	if p.completeCalls != 1 || p.streamCalls != 0 {
+		t.Fatalf("complete=%d stream=%d, want complete only", p.completeCalls, p.streamCalls)
+	}
+}
+
+func TestChatStreamUsesStreamingProvider(t *testing.T) {
+	p := &optInStreamingProvider{}
+	cfg, err := config.Load(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := New(p, cfg, "test", "", ModeLocal)
+
+	var gotDelta string
+	got, err := a.ChatStream("u", "hello", false, nil, func(delta string) { gotDelta += delta })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "stream ok" || gotDelta != "stream ok" {
+		t.Fatalf("got=%q delta=%q, want stream ok", got, gotDelta)
+	}
+	if p.completeCalls != 0 || p.streamCalls != 1 {
+		t.Fatalf("complete=%d stream=%d, want stream only", p.completeCalls, p.streamCalls)
 	}
 }

--- a/agent/stream_test.go
+++ b/agent/stream_test.go
@@ -1,0 +1,50 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/lucasnevespereira/nevinho/config"
+	"github.com/lucasnevespereira/nevinho/llm"
+)
+
+type fallbackProvider struct{ called bool }
+
+func (p *fallbackProvider) Complete(ctx context.Context, req *llm.Request) (*llm.Response, error) {
+	p.called = true
+	msg, _ := json.Marshal(map[string]any{"role": "assistant", "content": "fallback ok"})
+	return &llm.Response{Text: "fallback ok", AssistantMessage: msg, StopReason: llm.StopEndTurn}, nil
+}
+func (p *fallbackProvider) FormatUserMessage(text string, images []llm.Image) json.RawMessage {
+	msg, _ := json.Marshal(map[string]any{"role": "user", "content": text})
+	return msg
+}
+func (p *fallbackProvider) FormatToolResults(results []llm.ToolResult) []json.RawMessage { return nil }
+func (p *fallbackProvider) ReplaceToolResult(history []json.RawMessage, toolUseID, newOutput string) []json.RawMessage {
+	return history
+}
+func (p *fallbackProvider) Model() string { return "fake" }
+
+func TestChatStreamFallsBackToComplete(t *testing.T) {
+	p := &fallbackProvider{}
+	cfg, err := config.Load(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := New(p, cfg, "test", "", ModeLocal)
+	var streamed bool
+	got, err := a.ChatStream("u", "hello", false, nil, func(delta string) { streamed = true })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "fallback ok" {
+		t.Fatalf("got %q, want fallback ok", got)
+	}
+	if !p.called {
+		t.Fatal("Complete was not called")
+	}
+	if streamed {
+		t.Fatal("stream callback should not run for fallback provider")
+	}
+}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -162,7 +162,7 @@ func detectProvider(cfg *config.Config) llm.Provider {
 	switch {
 	case cfg.OllamaModel != "":
 		logger.Info("provider: ollama (" + cfg.OllamaModel + ")")
-		return llm.NewOpenAI("", pc.OllamaURL, cfg.OllamaModel)
+		return llm.NewOpenAICompatible("", pc.OllamaURL, cfg.OllamaModel)
 	case pc.AnthropicKey != "":
 		logger.Info("provider: anthropic")
 		return llm.NewAnthropic(pc.AnthropicKey, "", "")

--- a/llm/anthropic.go
+++ b/llm/anthropic.go
@@ -109,6 +109,120 @@ func (a *Anthropic) Complete(ctx context.Context, req *Request) (*Response, erro
 	return resp, nil
 }
 
+func (a *Anthropic) StreamComplete(ctx context.Context, req *Request, cb StreamCallback) (*Response, error) {
+	tools := a.formatTools(req.Tools)
+	if len(tools) > 0 {
+		tools[len(tools)-1]["cache_control"] = map[string]string{"type": "ephemeral"}
+	}
+	body := map[string]interface{}{
+		"model":      a.model,
+		"max_tokens": req.MaxTokens,
+		"system": []map[string]interface{}{{
+			"type":          "text",
+			"text":          req.SystemPrompt,
+			"cache_control": map[string]string{"type": "ephemeral"},
+		}},
+		"messages": ensureSlice(req.Messages),
+		"tools":    tools,
+		"stream":   true,
+	}
+
+	resp := &Response{}
+	blocks := map[int]map[string]interface{}{}
+	var order []int
+	err := doSSE(ctx, a.baseURL+"/v1/messages", body, map[string]string{
+		"x-api-key":         a.apiKey,
+		"anthropic-version": "2023-06-01",
+		"content-type":      "application/json",
+	}, func(data []byte) error {
+		var ev struct {
+			Type         string                 `json:"type"`
+			Index        int                    `json:"index"`
+			ContentBlock map[string]interface{} `json:"content_block"`
+			Delta        struct {
+				Type        string `json:"type"`
+				Text        string `json:"text"`
+				PartialJSON string `json:"partial_json"`
+				StopReason  string `json:"stop_reason"`
+			} `json:"delta"`
+			Usage struct {
+				InputTokens              int `json:"input_tokens"`
+				OutputTokens             int `json:"output_tokens"`
+				CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+				CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+			} `json:"usage"`
+		}
+		if err := json.Unmarshal(data, &ev); err != nil {
+			return fmt.Errorf("parse stream chunk: %w", err)
+		}
+		if ev.Usage.InputTokens != 0 {
+			resp.Usage.In = ev.Usage.InputTokens
+		}
+		if ev.Usage.OutputTokens != 0 {
+			resp.Usage.Out = ev.Usage.OutputTokens
+		}
+		if ev.Usage.CacheCreationInputTokens != 0 {
+			resp.Usage.CacheWrite = ev.Usage.CacheCreationInputTokens
+		}
+		if ev.Usage.CacheReadInputTokens != 0 {
+			resp.Usage.CacheRead = ev.Usage.CacheReadInputTokens
+		}
+		switch ev.Type {
+		case "content_block_start":
+			blocks[ev.Index] = ev.ContentBlock
+			order = append(order, ev.Index)
+		case "content_block_delta":
+			b := blocks[ev.Index]
+			if b == nil {
+				b = map[string]interface{}{}
+				blocks[ev.Index] = b
+				order = append(order, ev.Index)
+			}
+			if ev.Delta.Type == "text_delta" && ev.Delta.Text != "" {
+				prev, _ := b["text"].(string)
+				b["text"] = prev + ev.Delta.Text
+				resp.Text += ev.Delta.Text
+				if cb != nil {
+					cb(ev.Delta.Text)
+				}
+			}
+			if ev.Delta.Type == "input_json_delta" && ev.Delta.PartialJSON != "" {
+				prev, _ := b["_partial_json"].(string)
+				b["_partial_json"] = prev + ev.Delta.PartialJSON
+			}
+		case "message_delta":
+			resp.StopReason = anthropicStopReason(ev.Delta.StopReason)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var content []map[string]interface{}
+	for _, idx := range order {
+		b := blocks[idx]
+		if b == nil {
+			continue
+		}
+		if partial, _ := b["_partial_json"].(string); partial != "" {
+			b["input"] = json.RawMessage(partial)
+			delete(b, "_partial_json")
+		}
+		content = append(content, b)
+		if b["type"] == "tool_use" {
+			input, _ := json.Marshal(b["input"])
+			resp.ToolCalls = append(resp.ToolCalls, ToolCall{ID: fmt.Sprint(b["id"]), Name: fmt.Sprint(b["name"]), Input: input})
+		}
+	}
+	if resp.StopReason == "" {
+		resp.StopReason = StopEndTurn
+	}
+	assistantMsg, _ := json.Marshal(map[string]interface{}{"role": "assistant", "content": content})
+	resp.AssistantMessage = assistantMsg
+	return resp, nil
+}
+
 // anthropicStopReason maps Anthropic's stop_reason onto the normalized set.
 func anthropicStopReason(s string) StopReason {
 	switch s {

--- a/llm/anthropic.go
+++ b/llm/anthropic.go
@@ -139,7 +139,15 @@ func (a *Anthropic) StreamComplete(ctx context.Context, req *Request, cb StreamC
 			Type         string                 `json:"type"`
 			Index        int                    `json:"index"`
 			ContentBlock map[string]interface{} `json:"content_block"`
-			Delta        struct {
+			Message      struct {
+				Usage struct {
+					InputTokens              int `json:"input_tokens"`
+					OutputTokens             int `json:"output_tokens"`
+					CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+					CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+				} `json:"usage"`
+			} `json:"message"`
+			Delta struct {
 				Type        string `json:"type"`
 				Text        string `json:"text"`
 				PartialJSON string `json:"partial_json"`
@@ -155,18 +163,10 @@ func (a *Anthropic) StreamComplete(ctx context.Context, req *Request, cb StreamC
 		if err := json.Unmarshal(data, &ev); err != nil {
 			return fmt.Errorf("parse stream chunk: %w", err)
 		}
-		if ev.Usage.InputTokens != 0 {
-			resp.Usage.In = ev.Usage.InputTokens
-		}
-		if ev.Usage.OutputTokens != 0 {
-			resp.Usage.Out = ev.Usage.OutputTokens
-		}
-		if ev.Usage.CacheCreationInputTokens != 0 {
-			resp.Usage.CacheWrite = ev.Usage.CacheCreationInputTokens
-		}
-		if ev.Usage.CacheReadInputTokens != 0 {
-			resp.Usage.CacheRead = ev.Usage.CacheReadInputTokens
-		}
+		applyAnthropicUsage(&resp.Usage, ev.Message.Usage.InputTokens, ev.Message.Usage.OutputTokens,
+			ev.Message.Usage.CacheCreationInputTokens, ev.Message.Usage.CacheReadInputTokens)
+		applyAnthropicUsage(&resp.Usage, ev.Usage.InputTokens, ev.Usage.OutputTokens,
+			ev.Usage.CacheCreationInputTokens, ev.Usage.CacheReadInputTokens)
 		switch ev.Type {
 		case "content_block_start":
 			blocks[ev.Index] = ev.ContentBlock
@@ -221,6 +221,21 @@ func (a *Anthropic) StreamComplete(ctx context.Context, req *Request, cb StreamC
 	assistantMsg, _ := json.Marshal(map[string]interface{}{"role": "assistant", "content": content})
 	resp.AssistantMessage = assistantMsg
 	return resp, nil
+}
+
+func applyAnthropicUsage(u *Usage, in, out, cacheWrite, cacheRead int) {
+	if in != 0 {
+		u.In = in
+	}
+	if out != 0 {
+		u.Out = out
+	}
+	if cacheWrite != 0 {
+		u.CacheWrite = cacheWrite
+	}
+	if cacheRead != 0 {
+		u.CacheRead = cacheRead
+	}
 }
 
 // anthropicStopReason maps Anthropic's stop_reason onto the normalized set.

--- a/llm/gemini.go
+++ b/llm/gemini.go
@@ -117,6 +117,86 @@ func (g *Gemini) Complete(ctx context.Context, req *Request) (*Response, error) 
 	return resp, nil
 }
 
+func (g *Gemini) StreamComplete(ctx context.Context, req *Request, cb StreamCallback) (*Response, error) {
+	body := geminiBody(req)
+	url := fmt.Sprintf("%s/v1beta/models/%s:streamGenerateContent?alt=sse&key=%s", g.baseURL, g.model, g.apiKey)
+	resp := &Response{}
+	var parts []json.RawMessage
+	err := doSSE(ctx, url, body, map[string]string{"Content-Type": "application/json"}, func(data []byte) error {
+		var raw struct {
+			Candidates []struct {
+				Content struct {
+					Role  string            `json:"role"`
+					Parts []json.RawMessage `json:"parts"`
+				} `json:"content"`
+				FinishReason string `json:"finishReason"`
+			} `json:"candidates"`
+			UsageMetadata struct {
+				PromptTokenCount     int `json:"promptTokenCount"`
+				CandidatesTokenCount int `json:"candidatesTokenCount"`
+			} `json:"usageMetadata"`
+		}
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return fmt.Errorf("parse stream chunk: %w", err)
+		}
+		if raw.UsageMetadata.PromptTokenCount != 0 {
+			resp.Usage.In = raw.UsageMetadata.PromptTokenCount
+		}
+		if raw.UsageMetadata.CandidatesTokenCount != 0 {
+			resp.Usage.Out = raw.UsageMetadata.CandidatesTokenCount
+		}
+		if len(raw.Candidates) == 0 {
+			return nil
+		}
+		cand := raw.Candidates[0]
+		if cand.FinishReason != "" {
+			resp.StopReason = geminiStopReason(cand.FinishReason, len(resp.ToolCalls) > 0)
+		}
+		for _, part := range cand.Content.Parts {
+			parts = append(parts, part)
+			var p struct {
+				Text         string `json:"text"`
+				FunctionCall *struct {
+					Name string          `json:"name"`
+					Args json.RawMessage `json:"args"`
+				} `json:"functionCall"`
+			}
+			json.Unmarshal(part, &p)
+			if p.Text != "" {
+				resp.Text += p.Text
+				if cb != nil {
+					cb(p.Text)
+				}
+			}
+			if p.FunctionCall != nil {
+				resp.ToolCalls = append(resp.ToolCalls, ToolCall{ID: p.FunctionCall.Name, Name: p.FunctionCall.Name, Input: p.FunctionCall.Args})
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp.StopReason == "" {
+		resp.StopReason = geminiStopReason("STOP", len(resp.ToolCalls) > 0)
+	}
+	assistantMsg, _ := json.Marshal(map[string]interface{}{"role": "model", "parts": parts})
+	resp.AssistantMessage = assistantMsg
+	return resp, nil
+}
+
+func geminiBody(req *Request) map[string]interface{} {
+	body := map[string]interface{}{"contents": ensureSlice(req.Messages)}
+	if req.SystemPrompt != "" {
+		body["system_instruction"] = map[string]interface{}{"parts": []map[string]interface{}{{"text": req.SystemPrompt}}}
+	}
+	if len(req.Tools) > 0 {
+		g := &Gemini{}
+		body["tools"] = []map[string]interface{}{{"function_declarations": g.formatTools(req.Tools)}}
+	}
+	return body
+}
+
 // geminiStopReason maps Gemini's finishReason onto the normalized set.
 // Gemini keeps finishReason as "STOP" even when the turn carries function
 // calls, so tool use is detected from the parsed parts, not the reason.

--- a/llm/http.go
+++ b/llm/http.go
@@ -64,14 +64,7 @@ func doHTTP(ctx context.Context, url string, body interface{}, headers map[strin
 			return nil, lastErr
 		}
 
-		delay := backoffDelay(attempt)
-		if resp.StatusCode == 429 {
-			if ra := resp.Header.Get("Retry-After"); ra != "" {
-				if secs, err := strconv.Atoi(ra); err == nil && secs > 0 && secs <= 60 {
-					delay = time.Duration(secs) * time.Second
-				}
-			}
-		}
+		delay := retryDelay(attempt, resp)
 		logger.Info(fmt.Sprintf("retry %d/%d: API %d", attempt+1, maxRetries-1, resp.StatusCode))
 		if !sleepWithContext(ctx, delay) {
 			return nil, ctx.Err()
@@ -86,6 +79,19 @@ func isRetryable(code int) bool {
 
 func backoffDelay(attempt int) time.Duration {
 	return time.Duration(1<<attempt) * time.Second
+}
+
+func retryDelay(attempt int, resp *http.Response) time.Duration {
+	delay := backoffDelay(attempt)
+	if resp.StatusCode != 429 {
+		return delay
+	}
+	if ra := resp.Header.Get("Retry-After"); ra != "" {
+		if secs, err := strconv.Atoi(ra); err == nil && secs > 0 && secs <= 60 {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	return delay
 }
 
 func sleepWithContext(ctx context.Context, d time.Duration) bool {
@@ -104,28 +110,58 @@ func doSSE(ctx context.Context, url string, body interface{}, headers map[string
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBody))
-	if err != nil {
-		return err
-	}
-	for k, v := range headers {
-		req.Header.Set(k, v)
-	}
-	req.Header.Set("Accept", "text/event-stream")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		if ctx.Err() != nil {
+
+	var lastErr error
+	for attempt := range maxRetries {
+		req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBody))
+		if err != nil {
+			return err
+		}
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+		req.Header.Set("Accept", "text/event-stream")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			lastErr = err
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if attempt < maxRetries-1 {
+				logger.Info(fmt.Sprintf("retry %d/%d: %v", attempt+1, maxRetries-1, err))
+				if !sleepWithContext(ctx, backoffDelay(attempt)) {
+					return ctx.Err()
+				}
+			}
+			continue
+		}
+
+		if resp.StatusCode == 200 {
+			err := readSSE(ctx, resp.Body, onData)
+			resp.Body.Close()
+			return err
+		}
+
+		respBody, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		lastErr = fmt.Errorf("API %d: %s", resp.StatusCode, string(respBody))
+
+		if !isRetryable(resp.StatusCode) || attempt == maxRetries-1 {
+			return lastErr
+		}
+
+		delay := retryDelay(attempt, resp)
+		logger.Info(fmt.Sprintf("retry %d/%d: API %d", attempt+1, maxRetries-1, resp.StatusCode))
+		if !sleepWithContext(ctx, delay) {
 			return ctx.Err()
 		}
-		return err
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		b, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("API %d: %s", resp.StatusCode, string(b))
-	}
+	return lastErr
+}
 
-	scanner := bufio.NewScanner(resp.Body)
+func readSSE(ctx context.Context, r io.Reader, onData func([]byte) error) error {
+	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	var event strings.Builder
 	flush := func() error {

--- a/llm/http.go
+++ b/llm/http.go
@@ -1,6 +1,7 @@
 package llm
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -8,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/lucasnevespereira/nevinho/logger"
@@ -95,6 +97,71 @@ func sleepWithContext(ctx context.Context, d time.Duration) bool {
 	case <-t.C:
 		return true
 	}
+}
+
+func doSSE(ctx context.Context, url string, body interface{}, headers map[string]string, onData func([]byte) error) error {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return err
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API %d: %s", resp.StatusCode, string(b))
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var event strings.Builder
+	flush := func() error {
+		if event.Len() == 0 {
+			return nil
+		}
+		data := strings.TrimSpace(event.String())
+		event.Reset()
+		if data == "" || data == "[DONE]" {
+			return nil
+		}
+		return onData([]byte(data))
+	}
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			if err := flush(); err != nil {
+				return err
+			}
+			continue
+		}
+		if strings.HasPrefix(line, ":") || !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		if event.Len() > 0 {
+			event.WriteByte('\n')
+		}
+		event.WriteString(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+	}
+	if err := scanner.Err(); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return err
+	}
+	return flush()
 }
 
 func ensureSlice(msgs []json.RawMessage) []json.RawMessage {

--- a/llm/http_test.go
+++ b/llm/http_test.go
@@ -2,6 +2,8 @@ package llm
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 )
@@ -60,5 +62,54 @@ func TestSleepWithContext_Cancellation(t *testing.T) {
 	}
 	if elapsed > 100*time.Millisecond {
 		t.Errorf("took %v, should return immediately on cancelled context", elapsed)
+	}
+}
+
+func TestDoSSERetriesRetryableStatus(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			http.Error(w, "try again", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"ok\":true}\n\n"))
+	}))
+	defer srv.Close()
+
+	var got string
+	err := doSSE(context.Background(), srv.URL, map[string]string{"hello": "world"}, nil, func(data []byte) error {
+		got = string(data)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Fatalf("calls=%d, want 2", calls)
+	}
+	if got != `{"ok":true}` {
+		t.Fatalf("got data %q", got)
+	}
+}
+
+func TestDoSSEDoesNotRetryNonRetryableStatus(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		http.Error(w, "bad request", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	err := doSSE(context.Background(), srv.URL, map[string]string{"hello": "world"}, nil, func(data []byte) error {
+		t.Fatalf("unexpected data: %s", data)
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 1 {
+		t.Fatalf("calls=%d, want 1", calls)
 	}
 }

--- a/llm/openai.go
+++ b/llm/openai.go
@@ -9,19 +9,33 @@ import (
 )
 
 type OpenAI struct {
-	apiKey  string
-	baseURL string
-	model   string
+	apiKey             string
+	baseURL            string
+	model              string
+	streamIncludeUsage bool
 }
 
 func NewOpenAI(apiKey, baseURL, model string) *OpenAI {
+	return newOpenAI(apiKey, baseURL, model, true)
+}
+
+func NewOpenAICompatible(apiKey, baseURL, model string) *OpenAI {
+	return newOpenAI(apiKey, baseURL, model, false)
+}
+
+func newOpenAI(apiKey, baseURL, model string, streamIncludeUsage bool) *OpenAI {
 	if baseURL == "" {
 		baseURL = "https://api.openai.com"
 	}
 	if model == "" {
 		model = "gpt-4o-mini"
 	}
-	return &OpenAI{apiKey: apiKey, baseURL: baseURL, model: model}
+	return &OpenAI{
+		apiKey:             apiKey,
+		baseURL:            baseURL,
+		model:              model,
+		streamIncludeUsage: streamIncludeUsage,
+	}
 }
 
 func (o *OpenAI) Model() string { return o.model }
@@ -105,7 +119,9 @@ func (o *OpenAI) StreamComplete(ctx context.Context, req *Request, cb StreamCall
 		"messages":              messages,
 		"tools":                 o.formatTools(req.Tools),
 		"stream":                true,
-		"stream_options":        map[string]bool{"include_usage": true},
+	}
+	if o.streamIncludeUsage {
+		body["stream_options"] = map[string]bool{"include_usage": true}
 	}
 
 	resp := &Response{}

--- a/llm/openai.go
+++ b/llm/openai.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 type OpenAI struct {
@@ -89,6 +90,113 @@ func (o *OpenAI) Complete(ctx context.Context, req *Request) (*Response, error) 
 		})
 	}
 
+	return resp, nil
+}
+
+func (o *OpenAI) StreamComplete(ctx context.Context, req *Request, cb StreamCallback) (*Response, error) {
+	sysMsg, _ := json.Marshal(map[string]interface{}{
+		"role": "system", "content": req.SystemPrompt,
+	})
+	messages := append([]json.RawMessage{sysMsg}, ensureSlice(req.Messages)...)
+
+	body := map[string]interface{}{
+		"model":                 o.model,
+		"max_completion_tokens": req.MaxTokens,
+		"messages":              messages,
+		"tools":                 o.formatTools(req.Tools),
+		"stream":                true,
+		"stream_options":        map[string]bool{"include_usage": true},
+	}
+
+	resp := &Response{}
+	var text strings.Builder
+	var finish string
+	toolParts := map[int]*openAIToolCall{}
+	err := doSSE(ctx, o.baseURL+"/v1/chat/completions", body, map[string]string{
+		"Authorization": "Bearer " + o.apiKey,
+		"Content-Type":  "application/json",
+	}, func(data []byte) error {
+		var chunk struct {
+			Choices []struct {
+				Delta struct {
+					Role      string `json:"role"`
+					Content   string `json:"content"`
+					ToolCalls []struct {
+						Index    int    `json:"index"`
+						ID       string `json:"id"`
+						Type     string `json:"type"`
+						Function struct {
+							Name      string `json:"name"`
+							Arguments string `json:"arguments"`
+						} `json:"function"`
+					} `json:"tool_calls"`
+				} `json:"delta"`
+				FinishReason string `json:"finish_reason"`
+			} `json:"choices"`
+			Usage struct {
+				PromptTokens     int `json:"prompt_tokens"`
+				CompletionTokens int `json:"completion_tokens"`
+			} `json:"usage"`
+		}
+		if err := json.Unmarshal(data, &chunk); err != nil {
+			return fmt.Errorf("parse stream chunk: %w", err)
+		}
+		if chunk.Usage.PromptTokens != 0 || chunk.Usage.CompletionTokens != 0 {
+			resp.Usage = Usage{In: chunk.Usage.PromptTokens, Out: chunk.Usage.CompletionTokens}
+		}
+		for _, ch := range chunk.Choices {
+			if ch.Delta.Content != "" {
+				text.WriteString(ch.Delta.Content)
+				if cb != nil {
+					cb(ch.Delta.Content)
+				}
+			}
+			for _, tc := range ch.Delta.ToolCalls {
+				part := toolParts[tc.Index]
+				if part == nil {
+					part = &openAIToolCall{}
+					toolParts[tc.Index] = part
+				}
+				if tc.ID != "" {
+					part.ID = tc.ID
+				}
+				if tc.Type != "" {
+					part.Type = tc.Type
+				}
+				if tc.Function.Name != "" {
+					part.Function.Name += tc.Function.Name
+				}
+				if tc.Function.Arguments != "" {
+					part.Function.Arguments += tc.Function.Arguments
+				}
+			}
+			if ch.FinishReason != "" {
+				finish = ch.FinishReason
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	resp.Text = text.String()
+	resp.StopReason = openAIStopReason(finish)
+	msg := struct {
+		Role      string           `json:"role"`
+		Content   *string          `json:"content"`
+		ToolCalls []openAIToolCall `json:"tool_calls,omitempty"`
+	}{Role: "assistant"}
+	if resp.Text != "" {
+		msg.Content = &resp.Text
+	}
+	for i := 0; i < len(toolParts); i++ {
+		if tc := toolParts[i]; tc != nil {
+			msg.ToolCalls = append(msg.ToolCalls, *tc)
+			resp.ToolCalls = append(resp.ToolCalls, ToolCall{ID: tc.ID, Name: tc.Function.Name, Input: json.RawMessage(tc.Function.Arguments)})
+		}
+	}
+	assistantMsg, _ := json.Marshal(msg)
+	resp.AssistantMessage = assistantMsg
 	return resp, nil
 }
 

--- a/llm/provider.go
+++ b/llm/provider.go
@@ -22,6 +22,12 @@ type Provider interface {
 	Model() string
 }
 
+type StreamCallback func(delta string)
+
+type StreamingProvider interface {
+	StreamComplete(ctx context.Context, req *Request, cb StreamCallback) (*Response, error)
+}
+
 type Request struct {
 	SystemPrompt string
 	Messages     []json.RawMessage

--- a/llm/provider.go
+++ b/llm/provider.go
@@ -122,12 +122,12 @@ func Resolve(name string, pc config.ProviderConfig) (Provider, error) {
 		if pc.GroqKey == "" {
 			return nil, fmt.Errorf("GROQ_API_KEY not configured")
 		}
-		return NewOpenAI(pc.GroqKey, "https://api.groq.com/openai", strings.TrimPrefix(name, "groq:")), nil
+		return NewOpenAICompatible(pc.GroqKey, "https://api.groq.com/openai", strings.TrimPrefix(name, "groq:")), nil
 	case strings.HasPrefix(name, "openrouter:"):
 		if pc.OpenRouterKey == "" {
 			return nil, fmt.Errorf("OPENROUTER_API_KEY not configured")
 		}
-		return NewOpenAI(pc.OpenRouterKey, "https://openrouter.ai/api", strings.TrimPrefix(name, "openrouter:")), nil
+		return NewOpenAICompatible(pc.OpenRouterKey, "https://openrouter.ai/api", strings.TrimPrefix(name, "openrouter:")), nil
 	case strings.HasPrefix(name, "gpt-") || strings.HasPrefix(name, "o1-") || strings.HasPrefix(name, "o3-") || strings.HasPrefix(name, "o4-"):
 		if pc.OpenAIKey == "" {
 			return nil, fmt.Errorf("OPENAI_API_KEY not configured")
@@ -154,7 +154,7 @@ func Resolve(name string, pc config.ProviderConfig) (Provider, error) {
 		return NewGemini(pc.GeminiKey, "", name), nil
 	default:
 		if pc.OllamaURL != "" {
-			return NewOpenAI("", pc.OllamaURL, name), nil
+			return NewOpenAICompatible("", pc.OllamaURL, name), nil
 		}
 		if pc.OpenAIKey != "" {
 			return nil, fmt.Errorf("unknown model %q (no Ollama URL, model does not look like a known cloud model)", name)

--- a/llm/provider_test.go
+++ b/llm/provider_test.go
@@ -89,6 +89,7 @@ func TestResolveAllowsKnownOpenAI(t *testing.T) {
 	if p == nil {
 		t.Fatal("expected provider, got nil")
 	}
+	assertOpenAIStreamUsage(t, p, true)
 }
 
 func TestResolveAllowsAnyOllamaModel(t *testing.T) {
@@ -99,6 +100,7 @@ func TestResolveAllowsAnyOllamaModel(t *testing.T) {
 	if p == nil {
 		t.Fatal("expected provider, got nil")
 	}
+	assertOpenAIStreamUsage(t, p, false)
 }
 
 func TestResolveGroqRoutesAnyModelAfterPrefix(t *testing.T) {
@@ -109,6 +111,7 @@ func TestResolveGroqRoutesAnyModelAfterPrefix(t *testing.T) {
 	if p == nil {
 		t.Fatal("expected provider, got nil")
 	}
+	assertOpenAIStreamUsage(t, p, false)
 
 	// Any name after the prefix should resolve. The Groq catalog is large.
 	if _, err := Resolve("groq:something-new-tomorrow", config.ProviderConfig{GroqKey: "k"}); err != nil {
@@ -130,6 +133,18 @@ func TestResolveOpenRouterRoutesAnyModelAfterPrefix(t *testing.T) {
 	}
 	if p == nil {
 		t.Fatal("expected provider, got nil")
+	}
+	assertOpenAIStreamUsage(t, p, false)
+}
+
+func assertOpenAIStreamUsage(t *testing.T, p Provider, want bool) {
+	t.Helper()
+	o, ok := p.(*OpenAI)
+	if !ok {
+		t.Fatalf("provider type %T, want *OpenAI", p)
+	}
+	if o.streamIncludeUsage != want {
+		t.Fatalf("streamIncludeUsage=%v, want %v", o.streamIncludeUsage, want)
 	}
 }
 

--- a/llm/stream_test.go
+++ b/llm/stream_test.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -45,6 +46,88 @@ func TestAnthropicStreamComplete(t *testing.T) {
 	}
 	if resp.StopReason != StopEndTurn {
 		t.Fatalf("stop=%q", resp.StopReason)
+	}
+	if resp.Usage.In != 7 || resp.Usage.Out != 2 {
+		t.Fatalf("usage=%+v", resp.Usage)
+	}
+}
+
+func TestOpenAIStreamCompleteText(t *testing.T) {
+	srv := sseServer(t, "/v1/chat/completions", strings.Join([]string{
+		`data: {"choices":[{"delta":{"role":"assistant"}}]}`,
+		``,
+		`data: {"choices":[{"delta":{"content":"hel"}}]}`,
+		``,
+		`data: {"choices":[{"delta":{"content":"lo"},"finish_reason":"stop"}]}`,
+		``,
+		`data: {"choices":[],"usage":{"prompt_tokens":5,"completion_tokens":2}}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n"))
+	defer srv.Close()
+
+	p := NewOpenAI("key", srv.URL, "gpt-test")
+	var gotDelta string
+	resp, err := p.StreamComplete(context.Background(), &Request{SystemPrompt: "s", MaxTokens: 10}, func(d string) { gotDelta += d })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Text != "hello" || gotDelta != "hello" {
+		t.Fatalf("text=%q delta=%q, want hello", resp.Text, gotDelta)
+	}
+	if resp.StopReason != StopEndTurn {
+		t.Fatalf("stop=%q", resp.StopReason)
+	}
+	if resp.Usage.In != 5 || resp.Usage.Out != 2 {
+		t.Fatalf("usage=%+v", resp.Usage)
+	}
+	var msg struct {
+		Role    string  `json:"role"`
+		Content *string `json:"content"`
+	}
+	if err := json.Unmarshal(resp.AssistantMessage, &msg); err != nil {
+		t.Fatal(err)
+	}
+	if msg.Role != "assistant" || msg.Content == nil || *msg.Content != "hello" {
+		t.Fatalf("assistant message=%s", resp.AssistantMessage)
+	}
+}
+
+func TestOpenAIStreamCompleteToolCall(t *testing.T) {
+	srv := sseServer(t, "/v1/chat/completions", strings.Join([]string{
+		`data: {"choices":[{"delta":{"role":"assistant"}}]}`,
+		``,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"file_","arguments":"{\"path\""}}]}}]}`,
+		``,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"read","arguments":":\"README.md\"}"}}]},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: {"choices":[],"usage":{"prompt_tokens":9,"completion_tokens":4}}`,
+		``,
+	}, "\n"))
+	defer srv.Close()
+
+	p := NewOpenAI("key", srv.URL, "gpt-test")
+	var gotDelta string
+	resp, err := p.StreamComplete(context.Background(), &Request{SystemPrompt: "s", MaxTokens: 10}, func(d string) { gotDelta += d })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotDelta != "" || resp.Text != "" {
+		t.Fatalf("text=%q delta=%q, want no user-visible stream", resp.Text, gotDelta)
+	}
+	if resp.StopReason != StopToolUse {
+		t.Fatalf("stop=%q", resp.StopReason)
+	}
+	if resp.Usage.In != 9 || resp.Usage.Out != 4 {
+		t.Fatalf("usage=%+v", resp.Usage)
+	}
+	if len(resp.ToolCalls) != 1 {
+		t.Fatalf("tool calls=%+v", resp.ToolCalls)
+	}
+	tc := resp.ToolCalls[0]
+	if tc.ID != "call_1" || tc.Name != "file_read" || string(tc.Input) != `{"path":"README.md"}` {
+		t.Fatalf("tool call=%+v input=%s", tc, tc.Input)
 	}
 }
 

--- a/llm/stream_test.go
+++ b/llm/stream_test.go
@@ -1,0 +1,72 @@
+package llm
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func sseServer(t *testing.T, wantPath string, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.String(), wantPath) {
+			t.Fatalf("path = %s, want prefix %s", r.URL.String(), wantPath)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+func TestAnthropicStreamComplete(t *testing.T) {
+	srv := sseServer(t, "/v1/messages", strings.Join([]string{
+		`data: {"type":"message_start","message":{"usage":{"input_tokens":7}}}`,
+		``,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		``,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hel"}}`,
+		``,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"lo"}}`,
+		``,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}`,
+		``,
+	}, "\n"))
+	defer srv.Close()
+
+	p := NewAnthropic("key", srv.URL, "claude-test")
+	var gotDelta string
+	resp, err := p.StreamComplete(context.Background(), &Request{SystemPrompt: "s", MaxTokens: 10}, func(d string) { gotDelta += d })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Text != "hello" || gotDelta != "hello" {
+		t.Fatalf("text=%q delta=%q, want hello", resp.Text, gotDelta)
+	}
+	if resp.StopReason != StopEndTurn {
+		t.Fatalf("stop=%q", resp.StopReason)
+	}
+}
+
+func TestGeminiStreamComplete(t *testing.T) {
+	srv := sseServer(t, "/v1beta/models/gemini-test:streamGenerateContent", strings.Join([]string{
+		`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"hi"}]}}]}`,
+		``,
+		`data: {"candidates":[{"content":{"role":"model","parts":[{"text":" there"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":2}}`,
+		``,
+	}, "\n"))
+	defer srv.Close()
+
+	p := NewGemini("key", srv.URL, "gemini-test")
+	var gotDelta string
+	resp, err := p.StreamComplete(context.Background(), &Request{SystemPrompt: "s", MaxTokens: 10}, func(d string) { gotDelta += d })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Text != "hi there" || gotDelta != "hi there" {
+		t.Fatalf("text=%q delta=%q, want hi there", resp.Text, gotDelta)
+	}
+	if resp.Usage.In != 3 || resp.Usage.Out != 2 {
+		t.Fatalf("usage=%+v", resp.Usage)
+	}
+}

--- a/llm/stream_test.go
+++ b/llm/stream_test.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -129,6 +130,47 @@ func TestOpenAIStreamCompleteToolCall(t *testing.T) {
 	if tc.ID != "call_1" || tc.Name != "file_read" || string(tc.Input) != `{"path":"README.md"}` {
 		t.Fatalf("tool call=%+v input=%s", tc, tc.Input)
 	}
+}
+
+func TestOpenAIStreamCompleteIncludesUsageOption(t *testing.T) {
+	body := openAIStreamBody(t, NewOpenAI("key", "", "gpt-test"))
+	options, ok := body["stream_options"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("stream_options missing or wrong type: %#v", body["stream_options"])
+	}
+	if options["include_usage"] != true {
+		t.Fatalf("include_usage=%#v, want true", options["include_usage"])
+	}
+}
+
+func TestOpenAICompatibleStreamCompleteOmitsUsageOption(t *testing.T) {
+	body := openAIStreamBody(t, NewOpenAICompatible("key", "", "gpt-test"))
+	if _, ok := body["stream_options"]; ok {
+		t.Fatalf("compatible provider should omit stream_options: %#v", body["stream_options"])
+	}
+}
+
+func openAIStreamBody(t *testing.T, p *OpenAI) map[string]interface{} {
+	t.Helper()
+	var got map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := json.Unmarshal(b, &got); err != nil {
+			t.Fatal(err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}` + "\n\n"))
+	}))
+	defer srv.Close()
+	p.baseURL = srv.URL
+
+	if _, err := p.StreamComplete(context.Background(), &Request{SystemPrompt: "s", MaxTokens: 10}, nil); err != nil {
+		t.Fatal(err)
+	}
+	return got
 }
 
 func TestGeminiStreamComplete(t *testing.T) {

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -42,6 +42,7 @@ func Run(a *agent.Agent, cwd, configDir string) error {
 	// Buffered so the agent's tool callback never blocks on a slow UI. a
 	// full buffer just drops an event, which only costs a missed card.
 	events := make(chan agent.ToolEvent, 64)
+	stream := make(chan string, 256)
 	a.SetToolCallback(userID, func(ev agent.ToolEvent) {
 		select {
 		case events <- ev:
@@ -53,7 +54,7 @@ func Run(a *agent.Agent, cwd, configDir string) error {
 	// Inline rendering, not alt-screen. The terminal owns scrollback,
 	// selection, and URL clicks. Bubble Tea only manages the bottom live
 	// region (input, status, pickers).
-	p := tea.NewProgram(newModel(a, events, cwd))
+	p := tea.NewProgram(newModel(a, events, stream, cwd))
 	_, err := p.Run()
 	return err
 }
@@ -68,9 +69,12 @@ type responseMsg struct {
 // channel into the Bubble Tea message loop.
 type toolEventMsg agent.ToolEvent
 
+type streamDeltaMsg string
+
 type model struct {
 	agent  *agent.Agent
 	events chan agent.ToolEvent
+	stream chan string
 	cwd    string
 
 	input textarea.Model
@@ -86,6 +90,7 @@ type model struct {
 	width          int
 	height         int
 	ready          bool
+	liveResponse   string
 
 	// Submitted prompts, newest last. Up/down on an empty input walks
 	// this list so the user can re-send or edit a recent turn.
@@ -96,13 +101,13 @@ type model struct {
 	// user keeps typing into the textarea and the text after @ becomes
 	// the filter. mentionPrefix is the input value at the moment @ was
 	// pressed, so we can splice the chosen path back in.
-	mentioning     bool
-	mentionPrefix  string
-	mentionItems   []string
-	mentionCursor  int
+	mentioning    bool
+	mentionPrefix string
+	mentionItems  []string
+	mentionCursor int
 }
 
-func newModel(a *agent.Agent, events chan agent.ToolEvent, cwd string) model {
+func newModel(a *agent.Agent, events chan agent.ToolEvent, stream chan string, cwd string) model {
 	ta := textarea.New()
 	ta.Placeholder = inputPlaceholder
 	ta.Prompt = ""
@@ -119,6 +124,7 @@ func newModel(a *agent.Agent, events chan agent.ToolEvent, cwd string) model {
 	return model{
 		agent:      a,
 		events:     events,
+		stream:     stream,
 		cwd:        cwd,
 		input:      ta,
 		spin:       sp,
@@ -127,7 +133,7 @@ func newModel(a *agent.Agent, events chan agent.ToolEvent, cwd string) model {
 }
 
 func (m model) Init() tea.Cmd {
-	return tea.Batch(textarea.Blink, m.listen())
+	return tea.Batch(textarea.Blink, m.listen(), m.listenStream())
 }
 
 // listen pulls the next tool event off the channel. It re-issues itself on
@@ -142,10 +148,25 @@ func (m model) listen() tea.Cmd {
 	}
 }
 
+func (m model) listenStream() tea.Cmd {
+	return func() tea.Msg {
+		delta, ok := <-m.stream
+		if !ok {
+			return nil
+		}
+		return streamDeltaMsg(delta)
+	}
+}
+
 // send runs one blocking agent turn off the UI goroutine.
 func (m model) send(text string) tea.Cmd {
 	return func() tea.Msg {
-		out, err := m.agent.Chat(userID, text, false, nil)
+		out, err := m.agent.ChatStream(userID, text, false, nil, func(delta string) {
+			select {
+			case m.stream <- delta:
+			default:
+			}
+		})
 		return responseMsg{text: out, err: err}
 	}
 }
@@ -267,6 +288,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case responseMsg:
 		m.busy = false
+		m.liveResponse = ""
 		switch {
 		case msg.err != nil:
 			return m, m.printBlock(errorBlock{llm.FriendlyError(msg.err)})
@@ -280,6 +302,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		default:
 			return m, m.printBlock(agentBlock{msg.text})
 		}
+
+	case streamDeltaMsg:
+		if m.busy {
+			m.liveResponse += string(msg)
+		}
+		return m, m.listenStream()
 
 	case toolEventMsg:
 		ev := agent.ToolEvent(msg)
@@ -406,6 +434,7 @@ func (m model) decideApproval(approve bool) (tea.Model, tea.Cmd) {
 		answer = "yes"
 	}
 	m.busy = true
+	m.liveResponse = ""
 	return m, tea.Batch(m.send(answer), m.spin.Tick)
 }
 
@@ -589,6 +618,7 @@ func (m model) submit() (tea.Model, tea.Cmd) {
 		return m, tea.Sequence(echo, cmd)
 	}
 	m.busy = true
+	m.liveResponse = ""
 	return m, tea.Batch(
 		m.printBlock(userBlock{text}),
 		m.send(text),
@@ -777,12 +807,12 @@ func (m model) View() string {
 	}
 	// Leading blank row keeps the live region from hugging the last
 	// printed block in scrollback.
-	return lipgloss.JoinVertical(lipgloss.Left,
-		"",
-		m.workingLine(),
-		bottom,
-		m.statusBar(),
-	)
+	parts := []string{""}
+	if m.liveResponse != "" {
+		parts = append(parts, agentBlock{m.liveResponse}.render(m.contentWidth()))
+	}
+	parts = append(parts, m.workingLine(), bottom, m.statusBar())
+	return lipgloss.JoinVertical(lipgloss.Left, parts...)
 }
 
 // mentionPickerRows caps how many file rows the @-picker shows at once.


### PR DESCRIPTION
## Summary
- add optional streaming provider interface and ChatStream agent entrypoint
- stream TUI assistant responses while keeping Discord on blocking Chat
- implement SSE streaming for OpenAI-compatible, Anthropic, and Gemini providers

## Test Plan
- go test ./...